### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 A Model Context Protocol (MCP) server that provides **read-only** MySQL database queries for AI assistants. Execute queries, explore database structures, and investigate your data directly from your AI-powered tools.
 
+<a href="https://glama.ai/mcp/servers/@devakone/mysql-query-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devakone/mysql-query-mcp-server/badge" alt="MySQL Query Server MCP server" />
+</a>
+
 ## Supported AI Tools
 
 This MCP server works with any tool that supports the Model Context Protocol, including:
@@ -312,4 +316,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ---
 
-For more information or support, please [open an issue](https://github.com/devakone/mysql-query-mcp-server/issues) on the GitHub repository. 
+For more information or support, please [open an issue](https://github.com/devakone/mysql-query-mcp-server/issues) on the GitHub repository.


### PR DESCRIPTION
This PR adds a badge for the [MySQL Query MCP Server](https://glama.ai/mcp/servers/@devakone/mysql-query-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@devakone/mysql-query-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@devakone/mysql-query-mcp-server/badge" alt="MySQL Query Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.