### PR TITLE
fix(security): stop returning database credentials in tool responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,13 @@ SELECT * FROM users LIMIT 10;
 Get detailed information about your database:
 
 - Server version
-- Connection status
-- Database variables
-- Process list
+- Connection status and uptime
+- Selected server variables (character set, timezone, timeouts, connection limits)
+- Connection counters (threads connected, threads running, query counts)
 - Available databases
+
+The full `SHOW VARIABLES` output and the server process list are deliberately not
+reported. See [SECURITY.md](SECURITY.md).
 
 ### 3. environments
 
@@ -249,7 +252,17 @@ Use the environments tool to show me which database environments are available.
 - ✅ Each environment has its own isolated connection pool
 - ✅ SSL connections are supported for production environments
 - ✅ Query timeouts prevent runaway operations
-- ⚠️ Consider using secure credential management for database credentials
+- ✅ Tool responses never include configuration values, and are checked for secrets before
+  being returned
+- ⚠️ Credentials are still configured as plaintext environment variables in your MCP client
+  config. Keep that file out of version control
+
+### If you used a version before 1.3.0
+
+Versions up to and including 1.2.2 returned database credentials in the `environments`
+tool response, which means they could have been written into an AI chat transcript.
+**Rotate any credential you configured through this server.** Details are in
+[SECURITY.md](SECURITY.md).
 
 ## Troubleshooting
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,88 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please report security issues privately through
+[GitHub Security Advisories](https://github.com/devakone/mysql-query-mcp-server/security/advisories/new)
+rather than opening a public issue. I aim to acknowledge reports within a few days.
+
+## Advisory: database credentials returned in tool responses
+
+**Affected versions:** all releases up to and including 1.2.2
+**Fixed in:** 1.3.0
+**Severity:** high, if you configured a production or otherwise sensitive database
+
+### What happened
+
+The `environments` tool returned a `debug` object containing every environment variable
+matching `*_DB_*`, along with its value. That included `*_DB_PASS`. Calling the tool, which
+an AI assistant would do whenever asked something like "what databases can you see?",
+returned the host, username, and plaintext password for every configured environment,
+production included.
+
+Two related problems are fixed in the same release:
+
+- The `info` tool returned the complete output of `SHOW VARIABLES` and `SHOW PROCESSLIST`.
+  The process list contains the in-flight query text of every other session on the server,
+  which may belong to other applications and other people.
+- Debug logging on stderr printed hostnames, usernames, and in one path the contents of
+  configuration variables. MCP clients capture server stderr and write it to their own log
+  files on disk.
+
+### Why this matters even though the server runs locally
+
+This is a local stdio server, so its configuration file already lives inside the
+developer's own trust boundary. Storing credentials in that file is the pattern the MCP
+specification prescribes for stdio transports and is not the problem.
+
+The problem is that a tool *response* is a different boundary. Whatever a tool returns is
+written into the calling model's context and into a saved conversation transcript. That
+transcript is typically sent to a hosted inference API, persisted, and possibly synced
+across devices, quoted into later turns, or pasted into a bug report. A credential in a
+tool response has therefore left the machine it was configured on.
+
+There is a second consequence. Because the credentials were handed out on request, they
+were reachable by prompt injection: any untrusted content the model read, such as a row in
+a database or a web page, could ask for the `environments` tool output and get the
+production password. A credential sitting in a config file cannot be reached that way.
+
+### What you should do
+
+**Rotate every database credential you have ever configured through this server**,
+including development and staging, and including any credential you believe was only ever
+used locally. Do this even if you cannot find the credential in a transcript. Transcript
+retention and syncing behavior varies by client, and the cost of rotating is much lower
+than the cost of assuming it was never exposed.
+
+If your MySQL user was granted more than read access, treat rotation as urgent. Check the
+grants while you are there:
+
+```sql
+SHOW GRANTS FOR CURRENT_USER();
+```
+
+Then upgrade:
+
+```bash
+npm install -g mysql-query-mcp-server@latest
+```
+
+### What changed in the fix
+
+- The `environments` tool now returns environment names and how each one was configured,
+  and nothing else.
+- The `info` tool reports an allowlist of server variables and aggregate connection
+  counters. The full variable dump and the process list are gone.
+- Every tool response passes through a guard before it leaves the process. The guard scans
+  for the value of any secret-named environment variable, for configuration-shaped keys,
+  and for a small set of unmistakable secret shapes (AWS keys, PEM blocks, connection URIs
+  with an embedded password). A response that matches is blocked rather than scrubbed, so
+  it fails closed.
+- All logging goes through a single redacting logger, and verbose logging now requires
+  `DEBUG=true` rather than always being on.
+- Tests cover each of the above, including a test that reconstructs the original leaky
+  response and asserts that the guard rejects it.
+
+### Credit
+
+Found in production use by the maintainer.

--- a/docs/product-brief-credentials.md
+++ b/docs/product-brief-credentials.md
@@ -1,0 +1,292 @@
+# Product Brief: Credential Handling
+
+Status: draft for review
+Owner: @devakone
+Date: 2026-08-04
+
+## Context
+
+`mysql-query-mcp-server` is a local stdio MCP server. Each developer's AI client (Claude
+Code, Claude Desktop, Cursor, Windsurf) spawns it as a subprocess and talks to it over
+stdin/stdout. It supports four fixed environments: local, development, staging, production.
+
+Today the only supported way to give it credentials is to paste them as plaintext
+environment variables in the MCP client's config file:
+
+```json
+"env": {
+  "PRODUCTION_DB_HOST": "prod.example.com",
+  "PRODUCTION_DB_USER": "mcp_user",
+  "PRODUCTION_DB_PASS": "actual-production-password",
+  "PRODUCTION_DB_NAME": "app"
+}
+```
+
+This matches what the MCP specification prescribes for stdio servers, which says
+implementations on stdio "SHOULD NOT" use the OAuth authorization flow and should
+"instead retrieve credentials from the environment." Reading credentials from the
+environment is not the problem and is not changing. The problem is that the only
+documented way to populate that environment is to write the password down in a file.
+
+Two consequences, one sharp and one slow:
+
+1. The `environments` tool currently returns a `debug.envVars` object containing every
+   `*_DB_*` variable and its value, passwords included. Anything a tool returns is written
+   into the model's context and into a saved chat transcript, so credentials leave the
+   machine they were configured on. This has already happened in real use.
+2. The config file cannot be committed, shared, or used as a README example, because it
+   contains live secrets. Every developer redoes setup by hand and keeps a file of
+   production passwords in a project folder.
+
+## Who this is for
+
+The primary user is a developer who wants their AI assistant to answer questions about
+real application data, across more than one environment, without granting write access.
+They are comfortable with a JSON config file and a terminal. They may or may not be on
+AWS. They are not running a shared service and have no interest in operating one.
+
+A secondary user is that developer's teammate, who needs to get to the same working setup
+in as few steps as possible.
+
+## Goals
+
+- No tool response can carry a credential, config value, or anything secret-shaped.
+- A working config file contains no secrets, so it can be committed and shared.
+- Existing users keep working with no config changes required.
+- No new required dependencies, and no native build step, for the default install.
+
+## Non-goals
+
+- Remote or HTTP transport. Not in scope for any of these three features.
+- OAuth, Dynamic Client Registration, or resource indicators. The spec directs stdio
+  servers away from this, and for a process the user spawns themselves it adds no real
+  boundary: anyone who can start the server already has the access it would protect.
+- Per-user authorization policy (for example "Alice may query staging but not
+  production"). That only becomes meaningful with a shared deployment, which is a non-goal.
+- Replacing the existing read-only query restriction. It stays, unchanged.
+
+---
+
+## Feature 1: Tool responses stop echoing configuration
+
+### Problem
+
+Asking "which environments do I have?" returns hosts, usernames, and passwords. The user
+asked for a list of names.
+
+Two smaller versions of the same issue exist elsewhere. The `info` tool returns the full
+output of `SHOW VARIABLES` (which includes replication and file-path settings) and
+`SHOW PROCESSLIST` (which includes other sessions' in-flight query text, belonging to
+other applications and other people). Neither was asked for either.
+
+### What changes for the user
+
+`environments` returns what it says on the tin:
+
+```json
+{
+  "environments": [
+    { "name": "local",      "credentialSource": "env" },
+    { "name": "production", "credentialSource": "keychain" }
+  ],
+  "count": 2
+}
+```
+
+Naming the credential source is capability information, not a secret, and it is useful:
+it tells the user which environments are set up the safe way.
+
+`info` returns version, uptime, database list, connection counts, and a curated set of
+operational server variables. The full variable dump and the process list are gone.
+
+### Scope
+
+- Remove the `debug` block from the `environments` response.
+- Trim the `info` response to an explicit allowlist. Replace the process list with
+  aggregate connection counts.
+- Add a response guard at the single point where tool results are returned. It scans every
+  outbound response and refuses to send it if it matches a secret pattern: the value of any
+  env var whose name looks like a secret, a config-shaped key such as `PRODUCTION_DB_PASS`,
+  an AWS key, a connection string with an embedded password, or a PEM block. It fails
+  closed, meaning it returns an error instead of the response.
+- A test suite that fails the build on any of the above. This is the part that matters
+  longest, because it catches the next contributor who adds a debug field.
+- Stop the existing stderr debug logging from printing hosts, usernames, and passwords.
+  Route logging through the same redaction.
+
+### Out of scope
+
+Changing what `query` returns. Query results are the user's own data and are the point of
+the tool.
+
+### Acceptance criteria
+
+- No tool response contains any value from a `*_DB_PASS` variable.
+- The guard rejects a deliberately planted leaky response in a test.
+- A test adds a fake secret-shaped debug field to a tool and the build fails.
+- Existing `environments` and `info` tests pass against the new shapes.
+
+### Effort and risk
+
+Half a day. Low risk. One visible behavior change: callers who were reading
+`info.variables` or `info.processlist` get less back. Worth calling out in the changelog,
+and worth doing anyway.
+
+### Ship separately
+
+This lands on its own, ahead of the other two, with a security advisory and a note telling
+existing users to rotate any credential they have configured through this server.
+
+---
+
+## Feature 2: Config points at the password instead of containing it
+
+### Problem
+
+The password has to be written into a file, so the file cannot be shared or committed.
+
+### What changes for the user
+
+A new optional variable per environment, `<ENV>_DB_PASS_SOURCE`, holding a reference
+rather than a value. The server resolves it once at startup and keeps the result in memory
+only.
+
+```json
+"env": {
+  "PRODUCTION_DB_HOST": "prod.example.com",
+  "PRODUCTION_DB_USER": "mcp_user",
+  "PRODUCTION_DB_NAME": "app",
+  "PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"
+}
+```
+
+That config file has no secrets in it. It can be committed, and it can be the README
+example. A teammate copies it, runs one command to put their own password in their own
+keychain, and is done.
+
+Supported references:
+
+| Scheme | Example | Notes |
+|---|---|---|
+| `keychain:` | `keychain://mysql-query-mcp/production` | macOS Keychain, Windows Credential Manager, libsecret or `pass` on Linux |
+| `cmd:` | `cmd:op read op://Infra/prod-mysql/password` | Any command that prints the secret. Covers 1Password, Vault, `aws-vault`, and anything else a team already runs |
+| `aws-secrets:` | `aws-secrets://prod/mysql/mcp_user#password` | AWS Secrets Manager, using the caller's existing IAM credentials |
+| `aws-ssm:` | `aws-ssm:///prod/mysql/password` | SSM Parameter Store, SecureString |
+| `env:` | `env:SOME_OTHER_VAR` | Explicit indirection, mostly for CI |
+
+Plus a setup helper so this is a pleasant first five minutes rather than a research
+project:
+
+- `mysql-query-mcp credentials set production` prompts for the password and stores it in
+  the OS keychain.
+- `mysql-query-mcp doctor` resolves every configured source and reports whether each
+  environment is reachable, without starting the server and without printing any secret.
+
+### Design decisions
+
+- `keychain:` shells out to the platform tool (`security`, `secret-tool`, PowerShell).
+  No `keytar`. It is unmaintained and would force a native build on every install of what
+  is currently a pure-JS package.
+- AWS schemes lazy-load `@aws-sdk/*` as optional dependencies. Users who do not use them
+  never install them, and the error message when they are missing says exactly what to
+  install.
+- `<ENV>_DB_PASS` keeps working, documented as the local and throwaway path. If the
+  `production` environment uses it, the server warns on startup. It warns, it does not
+  refuse, because breaking existing installs is worse than the thing being warned about.
+- If both `_PASS` and `_PASS_SOURCE` are set, `_PASS_SOURCE` wins and the server warns.
+- A source that fails to resolve disables that one environment with a clear error. It does
+  not take down the server, so a broken production reference does not cost you local.
+
+### Out of scope
+
+Rotation and refresh. Resolution happens once at startup. If a password changes, restart
+the server. Feature 3 is where lifetime becomes a real concern.
+
+### Acceptance criteria
+
+- Existing configs using `<ENV>_DB_PASS` work with no changes.
+- Each scheme has a unit test with the underlying fetch mocked.
+- A failed resolution disables one environment and leaves the others working.
+- Configuring `production` via raw `_DB_PASS` produces a startup warning.
+- No resolved secret appears in any log line, at any log level, including on failure.
+- The README's example config contains no secrets.
+
+### Effort and risk
+
+Three to four days. Medium risk, mostly in cross-platform keychain behavior, which is
+where the test mocks and the `doctor` command earn their keep.
+
+---
+
+## Feature 3: No stored password at all for AWS RDS
+
+### Problem
+
+Even stored well, a long-lived database password is a thing that can leak and has to be
+rotated. For AWS-hosted databases it does not need to exist.
+
+### What changes for the user
+
+An `aws-iam:` source. The server signs a short-lived authentication token with the AWS
+credentials the developer already has, and uses it in place of a password.
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "aws-iam:"
+```
+
+There is no password to store, share, leak, or rotate. Access is granted and revoked
+through IAM, alongside everything else the team already manages there.
+
+### Design decisions and the honest caveat
+
+Tokens last 15 minutes and require SSL. `mysql2` does not accept a password callback on a
+connection pool, so a pool cannot transparently re-sign when the token expires. The
+options are to recycle the pool on a timer shorter than the token lifetime, or to open a
+connection per query and drop pooling for this path.
+
+Recommendation is a 10-minute pool recycle, which keeps pooling and stays well inside the
+token lifetime. This is the only part of this brief with genuine engineering risk, and it
+is the reason this ships last and ships behind an experimental label.
+
+### Acceptance criteria
+
+- A pool using `aws-iam:` still works after 20 minutes of idle time.
+- SSL is required and the server refuses to start this path without it.
+- Recycling does not drop an in-flight query.
+- Token values never appear in a log.
+
+### Effort and risk
+
+Three to five days including the connection-lifetime testing, which is the bulk of it.
+Higher risk. Ships as experimental, documented as such, and does not block features 1
+or 2.
+
+---
+
+## Sequencing and release plan
+
+| | Release | Notes |
+|---|---|---|
+| Feature 1 | Immediate, own PR | Security advisory, changelog security entry, explicit recommendation to rotate every credential configured through this server |
+| Feature 2 | Next minor | Purely additive. README rewrite and a migration note for users moving off inline passwords |
+| Feature 3 | Following minor | Labeled experimental |
+
+Feature 1 does not wait for the others.
+
+## How we know it worked
+
+- The example config in the README contains no secrets, and it is the config we tell
+  people to use.
+- Setting up a second machine, or a teammate, takes one file copy plus one command.
+- The test suite fails if a future change puts anything secret-shaped in a tool response.
+- Nobody has to think about the word "rotate" for an AWS environment.
+
+## Open questions
+
+1. Should `production` configured via raw `_DB_PASS` eventually become a hard failure, or
+   stay a warning forever? Proposing warning now, revisit after feature 2 has been out a
+   while.
+2. Is a first-class `1password:` scheme worth it, or is `cmd:op read ...` good enough?
+   Proposing `cmd:` only, since it covers every vendor for the same effort.
+3. Feature 1 trims the `info` response. Is anyone depending on the full variable dump?
+   Assuming no, since it was never a documented contract.

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "vitest": "^3.1.1"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=22.13.0"
       }
     },
     "node_modules/@cspotcode/source-map-support": {

--- a/src/db/pools.ts
+++ b/src/db/pools.ts
@@ -1,14 +1,12 @@
 import { createPool, Pool } from "mysql2/promise";
 import { Environment } from "../types/index.js";
 import { buildPoolOptions } from "./options.js";
-
-function debug(message: string, ...args: any[]) {
-  process.stderr.write(`DEBUG [Pools]: ${message} ${args.map(arg => JSON.stringify(arg)).join(' ')}\n`);
-}
+import { debug, warn } from "../logging.js";
 
 export const pools = new Map<Environment, Pool>();
 let poolsInitialized = false;
 
+// Map of environment to env var prefix
 const ENV_PREFIX_MAP = {
   local: 'LOCAL',
   development: 'DEVELOPMENT',
@@ -18,66 +16,50 @@ const ENV_PREFIX_MAP = {
 
 export function initializePools() {
   if (poolsInitialized) {
-    debug("Pools already initialized");
+    debug('pools', 'pools already initialized');
     return;
   }
-
-  debug("Initializing database pools...");
-  debug("Environment enum options:", Object.values(Environment.enum));
 
   Object.values(Environment.enum).forEach((env) => {
     const envPrefix = ENV_PREFIX_MAP[env];
     const config = buildPoolOptions(envPrefix);
 
-    debug(`=== Initializing pool for ${env} environment ===`);
-    debug(`Using prefix: ${envPrefix}`);
-    debug(`HOST: ${process.env[`${envPrefix}_DB_HOST`]}`);
-    debug(`USER: ${process.env[`${envPrefix}_DB_USER`]}`);
-    debug(`DB: ${process.env[`${envPrefix}_DB_NAME`]}`);
-    debug(`PASS: ${process.env[`${envPrefix}_DB_PASS`] ? "set" : "not set"}`);
-    debug(`PORT: ${config.port ?? "default"}`);
-    debug(`SSL: ${process.env[`${envPrefix}_DB_SSL`] ?? process.env.MCP_MYSQL_SSL}`);
+    // Only presence is logged, never the values. stderr is captured by the MCP
+    // client and written to its log files.
+    debug('pools', `initializing ${env}`, {
+      hasHost: !!config.host,
+      hasUser: !!config.user,
+      hasPassword: !!config.password,
+      hasDatabase: !!config.database,
+      port: config.port ?? 3306,
+      ssl: !!config.ssl,
+    });
 
     if (config.host && config.user && config.password && config.database) {
-      debug(`Creating pool for ${env} with config:`, {
-        host: config.host,
-        user: config.user,
-        database: config.database,
-        port: config.port ?? 3306,
-        ssl: config.ssl,
-        dateStrings: config.dateStrings,
-        timezone: config.timezone,
-        hasPassword: !!config.password,
-      });
-
       try {
         pools.set(env, createPool(config));
-        debug(`Pool created successfully for ${env}`);
+        debug('pools', `pool created for ${env}`);
       } catch (error) {
-        debug(`Error creating pool for ${env}:`, error);
+        const message = error instanceof Error ? error.message : 'Unknown error';
+        warn('pools', `could not create pool for ${env}`, { message });
       }
     } else {
-      debug(`Missing configuration for ${env}:`, {
-        hasHost: !!config.host,
-        hasUser: !!config.user,
-        hasPass: !!config.password,
-        hasDB: !!config.database,
-      });
+      debug('pools', `skipping ${env}: incomplete configuration`);
     }
   });
 
   poolsInitialized = true;
-  debug("Pools map keys:", Array.from(pools.keys()));
+  debug('pools', 'initialization complete', { configured: Array.from(pools.keys()) });
 }
 
 export async function closePools() {
   for (const [env, pool] of pools.entries()) {
     try {
-      debug(`Closing pool for ${env}...`);
       await pool.end();
-      debug(`Pool for ${env} closed successfully`);
+      debug('pools', `closed pool for ${env}`);
     } catch (error) {
-      debug(`Error closing pool for ${env}:`, error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      debug('pools', `error closing pool for ${env}`, { message });
     }
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ import {
   ListToolsRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { initializePools, closePools } from "./db/pools.js";
+import { debug, warn } from "./logging.js";
+import { guardToolResponse } from "./security/guard.js";
 import {
   queryToolName,
   queryToolDescription,
@@ -39,33 +41,13 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const projectRoot = resolve(__dirname, '..');
 
-function debug(message: string, ...args: any[]) {
-  if (process.env.DEBUG === 'true') {
-    const timestamp = new Date().toISOString();
-    const logMessage = `[${timestamp}] DEBUG: ${message} ${args.map(arg => JSON.stringify(arg)).join(' ')}\n`;
-    process.stderr.write(logMessage);
-  }
-}
-
 // Load environment variables before any other imports
 const envPath = resolve(projectRoot, '.env');
 config({ path: envPath });
 
-// Debug environment variables
-debug('Environment variables loaded:', {
-  __dirname,
-  projectRoot,
-  envPath,
-  PRODUCTION_DB_HOST: process.env.PRODUCTION_DB_HOST,
-  PRODUCTION_DB_USER: process.env.PRODUCTION_DB_USER,
-  PRODUCTION_DB_NAME: process.env.PRODUCTION_DB_NAME,
-  DEVELOPMENT_DB_HOST: process.env.DEVELOPMENT_DB_HOST,
-  LOCAL_DB_HOST: process.env.LOCAL_DB_HOST,
-});
+debug('startup', 'environment loaded', { projectRoot, envPath });
 
 initializePools();
-
-debug('Tools imported successfully');
 
 /**
  * MCP server providing MySQL database tools:
@@ -75,7 +57,6 @@ debug('Tools imported successfully');
  */
 
 // Create an MCP server instance
-debug('Creating MCP server instance...');
 const server = new Server(
   {
     name: "mysql-mcp-server",
@@ -132,13 +113,10 @@ const server = new Server(
     },
   },
 );
-debug('Server instance created');
 
 // Register ListTools handler
-debug('Registering ListTools handler...');
 server.setRequestHandler(ListToolsRequestSchema, async () => {
-  debug('Handling ListTools request');
-  debug('Tool names available:', { queryToolName, infoToolName, environmentsToolName });
+  debug('server', 'handling ListTools request');
   
   const toolsList = {
     tools: [
@@ -191,99 +169,79 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       },
     ],
   };
-  debug('Returning tools list:', toolsList);
   return toolsList;
 });
-debug('ListTools handler registered');
 
 // Register call tool handler
-debug('Registering CallTool handler...');
 server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
-  debug('Handling CallTool request:', { name, args });
+  debug('server', 'handling CallTool request', { name });
 
   try {
     switch (name) {
       case queryToolName: {
-        debug('Validating query tool arguments...');
         const validated = QueryToolSchema.parse(args);
-        debug('Validated query tool args:', validated);
-        debug('Executing query tool...');
-        return await runQueryTool(validated);
+        return guardToolResponse(name, await runQueryTool(validated));
       }
       case infoToolName: {
-        debug('Validating info tool arguments...');
         const validated = InfoToolSchema.parse(args);
-        debug('Validated info tool args:', validated);
-        debug('Executing info tool...');
-        return await runInfoTool(validated);
+        return guardToolResponse(name, await runInfoTool(validated));
       }
       case environmentsToolName: {
-        debug('Validating environments tool arguments...');
         const validated = EnvironmentsToolSchema.parse(args);
-        debug('Validated environments tool args:', validated);
-        debug('Executing environments tool...');
-        return await runEnvironmentsTool(validated);
+        return guardToolResponse(name, await runEnvironmentsTool(validated));
       }
       default: {
-        const errorMsg = `Unknown tool: ${name}`;
-        debug('Error:', errorMsg);
-        throw new Error(errorMsg);
+        throw new Error(`Unknown tool: ${name}`);
       }
     }
   } catch (error) {
-    debug('Error executing tool:', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    debug('server', 'tool execution failed', { name, message });
     throw error;
   }
 });
-debug('CallTool handler registered');
 
 // Handle process termination
 async function cleanup() {
-  debug('Starting cleanup...');
   await closePools();
-  debug('Server cleanup completed');
+  debug('server', 'cleanup completed');
 }
 
 // Clean server startup function matching the PostgreSQL example
 async function runServer() {
-  debug('Starting server...');
   const transport = new StdioServerTransport();
-  
-  debug('Connecting server to transport...');
+
   await server.connect(transport);
-  debug('Server connected and running on stdio');
-  
-  debug('Server initialization complete and ready for requests');
+  debug('server', 'connected and running on stdio');
+
   process.stderr.write('[MCP-MYSQL-SERVER] Ready to handle requests\n');
 }
 
 // Simple error handler for main function
 runServer().catch(error => {
-  debug('Failed to start MCP server:', error);
-  console.error('Failed to start MCP server:', error);
+  const message = error instanceof Error ? error.message : String(error);
+  warn('server', 'failed to start MCP server', { message });
   process.exit(1);
 });
 
 // Handle process signals for clean shutdown
 process.on('SIGINT', async () => {
-  debug('Received SIGINT signal, shutting down...');
   await cleanup();
   process.exit(0);
 });
 
 process.on('SIGTERM', async () => {
-  debug('Received SIGTERM signal, shutting down...');
   await cleanup();
   process.exit(0);
 });
 
 // Handle uncaught errors
 process.on('uncaughtException', (error) => {
-  debug('Uncaught exception:', error);
+  debug('server', 'uncaught exception', { message: error.message });
 });
 
-process.on('unhandledRejection', (reason, promise) => {
+process.on('unhandledRejection', (reason) => {
   const message = reason instanceof Error ? reason.message : String(reason);
-  debug('Unhandled rejection:', { message, reason });
+  debug('server', 'unhandled rejection', { message });
 });

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -1,0 +1,32 @@
+import { redact } from './security/secrets.js';
+
+/**
+ * All server logging goes through here so that every line passes through
+ * redaction on its way to stderr. stderr is captured by the MCP client and
+ * written to its log files, so it is not a safe place for credentials either.
+ */
+
+function write(level: string, scope: string, message: string, data?: unknown): void {
+  const parts = [`[${new Date().toISOString()}]`, level, `[${scope}]`, message];
+
+  if (data !== undefined) {
+    try {
+      parts.push(JSON.stringify(data));
+    } catch {
+      parts.push('[unserializable]');
+    }
+  }
+
+  process.stderr.write(`${redact(parts.join(' '))}\n`);
+}
+
+/** Verbose tracing. Off unless DEBUG=true, because it is noisy by design. */
+export function debug(scope: string, message: string, data?: unknown): void {
+  if (process.env.DEBUG !== 'true') return;
+  write('DEBUG', scope, message, data);
+}
+
+/** Operational problems the user should see. Always emitted. */
+export function warn(scope: string, message: string, data?: unknown): void {
+  write('WARN', scope, message, data);
+}

--- a/src/security/guard.ts
+++ b/src/security/guard.ts
@@ -1,0 +1,54 @@
+import { scanForSecrets } from './secrets.js';
+import { warn } from '../logging.js';
+
+/**
+ * Thrown instead of returning a response that contains something secret-shaped.
+ * The message names the rules that fired and never includes the matched value.
+ */
+export class SecretLeakError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly rules: string[],
+  ) {
+    super(
+      `Response from the "${toolName}" tool was blocked because it appeared to contain ` +
+        `sensitive configuration (${rules.join(', ')}). This is a bug in the server, ` +
+        `not a problem with your query. Please report it.`,
+    );
+    this.name = 'SecretLeakError';
+  }
+}
+
+interface ToolResponse {
+  content: { type: string; text: string }[];
+}
+
+/**
+ * Last checkpoint before a tool response leaves the process.
+ *
+ * Anything returned here is written into the calling model's context and into a
+ * saved transcript, so it leaves the machine the credentials were configured on.
+ * That makes it a different trust boundary from the local config file, and this
+ * is the boundary being enforced.
+ *
+ * Fails closed: a suspect response is dropped, not scrubbed and forwarded.
+ * Scrubbing risks passing along a secret in a form the pattern did not quite
+ * match, and a tool that silently returns altered data is worse than one that
+ * reports an error.
+ */
+export function guardToolResponse<T extends ToolResponse>(toolName: string, response: T): T {
+  const findings = response.content
+    .filter((item) => typeof item.text === 'string')
+    .flatMap((item) => scanForSecrets(item.text));
+
+  if (findings.length > 0) {
+    const rules = [...new Set(findings.map((finding) => finding.rule))];
+    warn('guard', `blocked response from "${toolName}"`, {
+      rules,
+      details: findings.map((finding) => finding.detail),
+    });
+    throw new SecretLeakError(toolName, rules);
+  }
+
+  return response;
+}

--- a/src/security/secrets.ts
+++ b/src/security/secrets.ts
@@ -1,0 +1,161 @@
+/**
+ * Secret detection, used by the outbound tool-response guard and by the
+ * redacting logger.
+ *
+ * Two independent strategies run together:
+ *
+ *  1. Value matching. Any process.env value whose *name* looks like a secret is
+ *     treated as a literal string that must never appear in output. This is the
+ *     load-bearing rule: it catches a leak regardless of what the leaking field
+ *     is called or how it is nested.
+ *  2. Shape matching. A short list of unmistakable secret shapes (AWS keys, PEM
+ *     blocks, connection URIs with an embedded password) is caught even when the
+ *     value did not come from this process's own environment.
+ *
+ * Deliberately NOT detected, because a real query result may legitimately
+ * contain these and blocking them would break the tool:
+ *
+ *  - Hostnames and usernames by value. A `users` table has usernames in it.
+ *  - Object keys merely named `password` / `secret` / `token`. `SELECT
+ *    password_hash FROM users` is a query the user asked for; the row key is
+ *    their schema, not our config.
+ *  - Generic `password=...` text. Far too common inside real column data.
+ *
+ * The config-shaped-key rule below covers the case those looser rules were
+ * meant to catch, without the false positives: no tool response has any reason
+ * to contain a key like `PRODUCTION_DB_PASS`.
+ */
+
+/** Env var name fragments that mark that variable's value as a secret. */
+const SECRET_NAME_PATTERN =
+  /(PASS|PASSWD|PASSWORD|SECRET|TOKEN|CREDENTIAL|PRIVATE_KEY|APIKEY|API_KEY|ACCESS_KEY|SESSION)/i;
+
+/**
+ * Env var names shaped like this server's own database configuration, for
+ * example `PRODUCTION_DB_PASS` or `LOCAL_DB_HOST`. No tool response may use one
+ * of these as an object key.
+ */
+const CONFIG_KEY_PATTERN = /^[A-Z][A-Z0-9]*_DB_[A-Z_]+$/;
+
+/** Values shorter than this are too common to match on without false positives. */
+const MIN_SECRET_VALUE_LENGTH = 6;
+
+const SHAPE_RULES: { rule: string; pattern: RegExp }[] = [
+  { rule: 'aws-access-key-id', pattern: /\b(?:AKIA|ASIA|ABIA|ACCA)[0-9A-Z]{16}\b/ },
+  { rule: 'aws-secret-access-key', pattern: /\baws_secret_access_key\b/i },
+  { rule: 'github-token', pattern: /\bgh[pousr]_[A-Za-z0-9]{20,}\b/ },
+  { rule: 'private-key-block', pattern: /-----BEGIN (?:[A-Z ]+ )?PRIVATE KEY-----/ },
+  {
+    rule: 'connection-uri-with-password',
+    pattern:
+      /\b(?:mysql|mysqlx|mariadb|postgres(?:ql)?|mongodb(?:\+srv)?|redis|amqp):\/\/[^\s:/@]+:[^\s@]+@/i,
+  },
+];
+
+export interface SecretFinding {
+  /** Stable identifier for the rule that fired. */
+  rule: string;
+  /** Human-readable detail. Never contains the matched value itself. */
+  detail: string;
+}
+
+/**
+ * Collects the literal values this process must never emit, keyed by the env
+ * var they came from. Read fresh on every call so that tests and late-loaded
+ * configuration are picked up.
+ */
+export function collectSecretValues(env: NodeJS.ProcessEnv = process.env): Map<string, string> {
+  const values = new Map<string, string>();
+
+  for (const [name, value] of Object.entries(env)) {
+    if (!value || value.length < MIN_SECRET_VALUE_LENGTH) continue;
+    if (!SECRET_NAME_PATTERN.test(name)) continue;
+    values.set(name, value);
+  }
+
+  return values;
+}
+
+/** Walks a parsed JSON value and reports every object key that names DB config. */
+function findConfigKeys(value: unknown, path = '$', found: string[] = []): string[] {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => findConfigKeys(item, `${path}[${index}]`, found));
+    return found;
+  }
+
+  if (value && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      if (CONFIG_KEY_PATTERN.test(key)) {
+        found.push(`${path}.${key}`);
+      }
+      findConfigKeys(child, `${path}.${key}`, found);
+    }
+  }
+
+  return found;
+}
+
+/**
+ * Scans outbound text for secrets. Returns every finding rather than
+ * short-circuiting, so the caller can report the full picture.
+ */
+export function scanForSecrets(text: string, env: NodeJS.ProcessEnv = process.env): SecretFinding[] {
+  const findings: SecretFinding[] = [];
+
+  for (const [name, value] of collectSecretValues(env)) {
+    if (text.includes(value)) {
+      findings.push({
+        rule: 'env-secret-value',
+        detail: `contains the value of ${name}`,
+      });
+    }
+  }
+
+  for (const { rule, pattern } of SHAPE_RULES) {
+    if (pattern.test(text)) {
+      findings.push({ rule, detail: `matches the ${rule} pattern` });
+    }
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    parsed = undefined;
+  }
+
+  if (parsed !== undefined) {
+    for (const keyPath of findConfigKeys(parsed)) {
+      findings.push({
+        rule: 'configuration-key-in-response',
+        detail: `exposes a configuration key at ${keyPath}`,
+      });
+    }
+  }
+
+  return findings;
+}
+
+function globalize(pattern: RegExp): RegExp {
+  return pattern.flags.includes('g')
+    ? pattern
+    : new RegExp(pattern.source, `${pattern.flags}g`);
+}
+
+/**
+ * Replaces known secret values with a placeholder. Used on the logging path,
+ * where the goal is a message that is still useful rather than a hard failure.
+ */
+export function redact(text: string, env: NodeJS.ProcessEnv = process.env): string {
+  let result = text;
+
+  for (const [name, value] of collectSecretValues(env)) {
+    result = result.split(value).join(`[REDACTED:${name}]`);
+  }
+
+  for (const { rule, pattern } of SHAPE_RULES) {
+    result = result.replace(globalize(pattern), `[REDACTED:${rule}]`);
+  }
+
+  return result;
+}

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -1,13 +1,10 @@
 import { z } from "zod";
 import { Environment } from "../types/index.js";
+import { debug } from "../logging.js";
 
 export const environmentsToolName = "environments";
 export const environmentsToolDescription = "List available MySQL database environments";
 export const EnvironmentsToolSchema = z.object({});
-
-function debug(message: string, ...args: any[]) {
-  process.stderr.write(`DEBUG: ${message} ${args.map(arg => JSON.stringify(arg)).join(' ')}\n`);
-}
 
 // Map of environment to env var prefix
 const ENV_PREFIX_MAP = {
@@ -17,56 +14,50 @@ const ENV_PREFIX_MAP = {
   production: 'PRODUCTION'
 } as const;
 
-export async function runEnvironmentsTool(_params?: z.infer<typeof EnvironmentsToolSchema>): Promise<{ content: { type: string; text: string }[] }> {
-  try {
-    debug('=== Running environments tool ===');
-    
-    // Log all environment variables for debugging
-    const envVars = Object.keys(process.env)
-      .filter(key => key.includes('_DB_'))
-      .reduce((acc, key) => ({ ...acc, [key]: process.env[key] }), {});
-    
-    debug('Found DB-related environment variables:', envVars);
-    
-    const environments = Object.values(Environment.enum).filter(env => {
+/**
+ * Describes where an environment's password came from. Naming the mechanism is
+ * capability information, not a secret, and it tells the user which
+ * environments are configured which way.
+ */
+function credentialSourceFor(envPrefix: string): string {
+  return process.env[`${envPrefix}_DB_PASS`] ? 'env' : 'none';
+}
+
+/**
+ * Reports which environments are usable. This response describes capability
+ * only: environment names and how each one was configured. It must never carry
+ * configuration values. See src/security/guard.ts.
+ */
+export async function runEnvironmentsTool(
+  _params?: z.infer<typeof EnvironmentsToolSchema>,
+): Promise<{ content: { type: string; text: string }[] }> {
+  debug('environments', 'listing configured environments');
+
+  const environments = Object.values(Environment.enum)
+    .filter((env) => {
       const envPrefix = ENV_PREFIX_MAP[env];
 
-      // Check only for required variables that pools.ts uses
-      const hasConfig = !!(
+      // Check only for required variables that pools.ts uses.
+      return !!(
         process.env[`${envPrefix}_DB_HOST`] &&
         process.env[`${envPrefix}_DB_USER`] &&
         process.env[`${envPrefix}_DB_NAME`]
       );
+    })
+    .map((env) => ({
+      name: env,
+      credentialSource: credentialSourceFor(ENV_PREFIX_MAP[env]),
+    }));
 
-      debug(`Checking ${env} (${envPrefix}):`, {
-        prefix: envPrefix,
-        host: process.env[`${envPrefix}_DB_HOST`],
-        user: process.env[`${envPrefix}_DB_USER`],
-        db: process.env[`${envPrefix}_DB_NAME`],
-        hasConfig
-      });
+  debug('environments', 'available environments', environments.map((env) => env.name));
 
-      return hasConfig;
-    });
-
-    debug('Available environments:', environments);
-
-    // Return the environments in the format expected by the MCP protocol
-    return {
-      content: [{
-        type: "text",
-        text: JSON.stringify({
-          environments,
-          count: environments.length,
-          debug: {
-            envVars,
-            environments
-          }
-        }, null, 2),
-      }],
-    };
-  } catch (error) {
-    debug('Error in environments tool:', error);
-    throw error;
-  }
+  return {
+    content: [{
+      type: "text",
+      text: JSON.stringify({
+        environments,
+        count: environments.length,
+      }, null, 2),
+    }],
+  };
 }

--- a/src/tools/info.ts
+++ b/src/tools/info.ts
@@ -6,6 +6,66 @@ export const infoToolName = "info";
 export const infoToolDescription = "Get information about MySQL databases";
 export const InfoToolSchema = InfoParams;
 
+/**
+ * Server variables reported by this tool.
+ *
+ * This is an allowlist rather than the full `SHOW VARIABLES` output. The full
+ * output runs to several hundred entries and includes replication settings and
+ * filesystem paths, none of which this tool exists to surface. Add entries here
+ * when there is a reason to.
+ */
+const REPORTED_VARIABLES = [
+  'version',
+  'version_comment',
+  'default_storage_engine',
+  'character_set_server',
+  'collation_server',
+  'time_zone',
+  'system_time_zone',
+  'sql_mode',
+  'transaction_isolation',
+  'autocommit',
+  'read_only',
+  'super_read_only',
+  'max_connections',
+  'max_allowed_packet',
+  'wait_timeout',
+  'interactive_timeout',
+  'net_read_timeout',
+  'net_write_timeout',
+  'group_concat_max_len',
+  'lower_case_table_names',
+  'require_secure_transport',
+] as const;
+
+/** Status counters reported by this tool. Same reasoning as above. */
+const REPORTED_STATUS = [
+  'Uptime',
+  'Threads_connected',
+  'Threads_running',
+  'Queries',
+  'Slow_queries',
+] as const;
+
+function pick(source: Record<string, string>, keys: readonly string[]): Record<string, string> {
+  const picked: Record<string, string> = {};
+
+  for (const key of keys) {
+    if (source[key] !== undefined) {
+      picked[key] = source[key];
+    }
+  }
+
+  return picked;
+}
+
+function toVariableMap(rows: any[]): Record<string, string> {
+  return rows.reduce((acc: Record<string, string>, row: any) => {
+    acc[row.Variable_name] = row.Value;
+    return acc;
+  }, {});
+}
+
 export async function runInfoTool(params: z.infer<typeof InfoToolSchema>): Promise<{ content: { type: string; text: string }[] }> {
   const { environment } = params;
 
@@ -17,7 +77,7 @@ export async function runInfoTool(params: z.infer<typeof InfoToolSchema>): Promi
 
   try {
     const connection = await pool.getConnection();
-    
+
     try {
       // Get server version
       const [versionRows] = await connection.query("SELECT VERSION() as version") as [any[], any[]];
@@ -25,31 +85,25 @@ export async function runInfoTool(params: z.infer<typeof InfoToolSchema>): Promi
 
       // Get server status
       const [statusRows] = await connection.query("SHOW STATUS") as [any[], any[]];
-      const status = statusRows.reduce((acc: Record<string, string>, row: any) => {
-        acc[row.Variable_name] = row.Value;
-        return acc;
-      }, {});
+      const status = toVariableMap(statusRows);
 
       // Get server variables
       const [variableRows] = await connection.query("SHOW VARIABLES") as [any[], any[]];
-      const variables = variableRows.reduce((acc: Record<string, string>, row: any) => {
-        acc[row.Variable_name] = row.Value;
-        return acc;
-      }, {});
-
-      // Get process list
-      const [processRows] = await connection.query("SHOW PROCESSLIST") as [any[], any[]];
-      const processlist = processRows;
+      const variables = toVariableMap(variableRows);
 
       // Get databases
       const [databaseRows] = await connection.query("SHOW DATABASES") as [any[], any[]];
       const databases = databaseRows.map((row: any) => row.Database);
 
+      // SHOW PROCESSLIST is deliberately not reported. It exposes the in-flight
+      // query text of every other session on the server, which belongs to other
+      // applications and other people. Connection counts give the same
+      // operational signal without that.
       const info: DatabaseInfo = {
         version,
         status: status.Uptime ? `Up ${status.Uptime} seconds` : "Unknown",
-        variables,
-        processlist,
+        variables: pick(variables, REPORTED_VARIABLES),
+        counters: pick(status, REPORTED_STATUS),
         databases,
       };
 
@@ -66,4 +120,4 @@ export async function runInfoTool(params: z.infer<typeof InfoToolSchema>): Promi
     const message = error instanceof Error ? error.message : "Unknown error occurred";
     throw new Error(`Failed to get database info: ${message}`);
   }
-} 
+}

--- a/src/tools/query.ts
+++ b/src/tools/query.ts
@@ -1,10 +1,7 @@
 import { z } from "zod";
 import { QueryParams, QueryResult, Environment } from "../types/index.js";
 import { pools } from "../db/pools.js";
-
-function debug(message: string, ...args: any[]) {
-  process.stderr.write(`DEBUG [Query]: ${message} ${args.map(arg => JSON.stringify(arg)).join(' ')}\n`);
-}
+import { debug } from "../logging.js";
 
 export const queryToolName = "query";
 export const queryToolDescription = "Execute read-only SQL queries against MySQL databases";
@@ -13,80 +10,54 @@ export const QueryToolSchema = QueryParams;
 // Validate query is read-only
 export function isReadOnlyQuery(sql: string): boolean {
   const upperSql = sql.trim().toUpperCase();
-  return upperSql.startsWith("SELECT") || upperSql.startsWith("SHOW") || 
+  return upperSql.startsWith("SELECT") || upperSql.startsWith("SHOW") ||
          upperSql.startsWith("DESCRIBE") || upperSql.startsWith("DESC");
 }
 
 export async function runQueryTool(params: z.infer<typeof QueryToolSchema>): Promise<{ content: { type: string; text: string }[] }> {
   const { sql, environment: rawEnvironment, timeout = 30000 } = params;
-  
-  debug('Starting query execution with params:', { sql, environment: rawEnvironment, timeout });
-  debug('Raw environment type:', typeof rawEnvironment);
-  debug('Raw environment value:', rawEnvironment);
+
+  debug('query', 'starting query execution', { environment: rawEnvironment, timeout });
 
   // Validate query
   if (!isReadOnlyQuery(sql)) {
-    debug('Query validation failed: not a read-only query');
+    debug('query', 'rejected: not a read-only query');
     throw new Error("Only SELECT, SHOW, DESCRIBE, and DESC queries are allowed");
   }
-  debug('Query validation passed: is read-only');
 
   // Validate environment
-  debug('Validating environment:', rawEnvironment);
-  debug('Environment enum:', Environment);
-  debug('Environment enum values:', Object.values(Environment.enum));
   const environment = Environment.parse(rawEnvironment);
-  debug('Environment validated successfully:', environment);
-  debug('Validated environment type:', typeof environment);
-  debug('Validated environment value:', environment);
 
   // Get connection pool
-  debug('Getting connection pool for environment:', environment);
-  debug('Available pools:', Array.from(pools.keys()));
-  debug('Pool map type:', typeof pools);
-  debug('Pool keys type:', Array.from(pools.keys()).map(k => typeof k));
-  debug('Pool keys:', Array.from(pools.keys()));
-  debug('Environment type:', typeof environment);
-  debug('Environment value:', environment);
-  debug('Pool has environment?', pools.has(environment));
-  
   const pool = pools.get(environment);
   if (!pool) {
-    debug('No pool found for environment:', environment);
-    debug('Current pools state:', {
-      size: pools.size,
-      keys: Array.from(pools.keys()),
-      envType: typeof environment,
-      envValue: environment,
-      poolsType: typeof pools,
-      poolsEntries: Array.from(pools.entries()).map(([k]) => ({ key: k, type: typeof k }))
+    debug('query', 'no pool for environment', {
+      environment,
+      configured: Array.from(pools.keys()),
     });
     throw new Error(`No connection pool available for environment: ${environment}`);
   }
-  debug('Found pool for environment:', environment);
 
   try {
     // Execute query with timeout
     const startTime = Date.now();
-    debug('Getting connection from pool');
     const connection = await pool.getConnection();
-    debug('Connection acquired successfully');
-    
+
     try {
-      debug('Executing query with timeout:', timeout);
       const result = await Promise.race([
         connection.query(sql),
-        new Promise((_, reject) => 
+        new Promise((_, reject) =>
           setTimeout(() => reject(new Error(`Query timeout after ${timeout}ms`)), timeout)
         ),
       ]) as [any[], any[]];
 
       const [rows, fields] = result;
       const executionTime = Date.now() - startTime;
-      debug('Query executed successfully:', { 
-        rowCount: rows.length, 
+      debug('query', 'query executed', {
+        environment,
+        rowCount: rows.length,
         executionTime,
-        fieldCount: fields.length 
+        fieldCount: fields.length,
       });
 
       const queryResult: QueryResult = {
@@ -107,13 +78,11 @@ export async function runQueryTool(params: z.infer<typeof QueryToolSchema>): Pro
         }],
       };
     } finally {
-      debug('Releasing connection back to pool');
       connection.release();
-      debug('Connection released');
     }
   } catch (error) {
     const message = error instanceof Error ? error.message : "Unknown error occurred";
-    debug('Error executing query:', message);
+    debug('query', 'query failed', { environment, message });
     throw new Error(`Query execution failed: ${message}`);
   }
-} 
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -46,8 +46,10 @@ export interface QueryResult {
 export interface DatabaseInfo {
   version: string;
   status: string;
+  /** Allowlisted server variables. See REPORTED_VARIABLES in tools/info.ts. */
   variables: Record<string, string>;
-  processlist: unknown[];
+  /** Allowlisted status counters. Replaces the former processlist field. */
+  counters: Record<string, string>;
   databases: string[];
 }
 

--- a/tests/security/guard.test.ts
+++ b/tests/security/guard.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { guardToolResponse, SecretLeakError } from '../../src/security/guard.js';
+import { scanForSecrets, redact } from '../../src/security/secrets.js';
+
+/**
+ * These tests are the regression net for the credential-leak class of bug. The
+ * point is not to prove the current tools are clean (the per-tool tests do
+ * that), it is to prove that a future response carrying a secret gets stopped
+ * even if nobody remembers this file exists.
+ */
+
+function response(payload: unknown) {
+  return { content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }] };
+}
+
+describe('tool response guard', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    Object.keys(process.env).forEach((key) => {
+      if (key.includes('_DB_')) delete process.env[key];
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+  });
+
+  it('passes a response that describes capability only', () => {
+    process.env.PRODUCTION_DB_PASS = 'super-secret-prod-password';
+
+    const safe = response({
+      environments: [{ name: 'production', credentialSource: 'env' }],
+      count: 1,
+    });
+
+    expect(() => guardToolResponse('environments', safe)).not.toThrow();
+  });
+
+  it('blocks the exact bug that shipped: an env var dump', () => {
+    process.env.PRODUCTION_DB_HOST = 'prod.example.com';
+    process.env.PRODUCTION_DB_USER = 'mcp_user';
+    process.env.PRODUCTION_DB_PASS = 'super-secret-prod-password';
+
+    const leaky = response({
+      environments: ['production'],
+      debug: {
+        envVars: {
+          PRODUCTION_DB_HOST: process.env.PRODUCTION_DB_HOST,
+          PRODUCTION_DB_USER: process.env.PRODUCTION_DB_USER,
+          PRODUCTION_DB_PASS: process.env.PRODUCTION_DB_PASS,
+        },
+      },
+    });
+
+    expect(() => guardToolResponse('environments', leaky)).toThrow(SecretLeakError);
+  });
+
+  it('blocks a password value even when the field is named innocently', () => {
+    process.env.STAGING_DB_PASS = 'staging-password-value';
+
+    const leaky = response({ notes: 'connected using staging-password-value' });
+
+    expect(() => guardToolResponse('info', leaky)).toThrow(SecretLeakError);
+  });
+
+  it('blocks a configuration-shaped key even when the value is not a known secret', () => {
+    const leaky = response({ config: { DEVELOPMENT_DB_HOST: 'dev.example.com' } });
+
+    expect(() => guardToolResponse('environments', leaky)).toThrow(SecretLeakError);
+  });
+
+  it('names the rules that fired without repeating the secret', () => {
+    process.env.PRODUCTION_DB_PASS = 'super-secret-prod-password';
+
+    const leaky = response({ password: process.env.PRODUCTION_DB_PASS });
+
+    try {
+      guardToolResponse('environments', leaky);
+      expect.unreachable('guard should have thrown');
+    } catch (error) {
+      expect(error).toBeInstanceOf(SecretLeakError);
+      const leak = error as SecretLeakError;
+      expect(leak.rules).toContain('env-secret-value');
+      expect(leak.message).not.toContain('super-secret-prod-password');
+    }
+  });
+
+  it('fails closed rather than scrubbing and forwarding', () => {
+    process.env.LOCAL_DB_PASS = 'local-password-value';
+
+    const leaky = response({ value: 'local-password-value' });
+
+    expect(() => guardToolResponse('query', leaky)).toThrow();
+  });
+});
+
+describe('secret shape detection', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    Object.keys(process.env).forEach((key) => {
+      if (key.includes('_DB_')) delete process.env[key];
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it.each([
+    ['an AWS access key id', 'AKIAIOSFODNN7EXAMPLE'],
+    ['a MySQL connection URI with a password', 'mysql://root:hunter2@db.example.com:3306/app'],
+    ['a private key block', '-----BEGIN RSA PRIVATE KEY-----\nMIIEow==\n'],
+    ['a GitHub token', 'ghp_abcdefghijklmnopqrstuvwxyz0123456789'],
+  ])('detects %s', (_label, payload) => {
+    expect(scanForSecrets(payload).length).toBeGreaterThan(0);
+  });
+
+  it.each([
+    ['a column literally named password', '{"rows":[{"password_hash":"$2b$10$abcdefghijklmno"}]}'],
+    ['a username in a data row', '{"rows":[{"user":"admin","host":"prod.example.com"}]}'],
+    ['ordinary query output', '{"rows":[{"id":1,"email":"a@b.com"}],"rowCount":1}'],
+  ])('does not false-positive on %s', (_label, payload) => {
+    expect(scanForSecrets(payload)).toEqual([]);
+  });
+});
+
+describe('log redaction', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('replaces secret values in log lines', () => {
+    process.env.PRODUCTION_DB_PASS = 'super-secret-prod-password';
+
+    const line = redact('connecting with super-secret-prod-password');
+
+    expect(line).not.toContain('super-secret-prod-password');
+    expect(line).toContain('[REDACTED:PRODUCTION_DB_PASS]');
+  });
+});

--- a/tests/tools/environments.test.ts
+++ b/tests/tools/environments.test.ts
@@ -4,78 +4,112 @@ import { Environment } from '../../src/types/index.js';
 
 describe('environments tool', () => {
   const originalEnv = process.env;
-  
+
   beforeEach(() => {
     vi.resetModules();
     process.env = { ...originalEnv };
-    
+
     // Clean any environment-specific variables
     Object.keys(process.env).forEach(key => {
       if (key.includes('_DB_')) {
         delete process.env[key];
       }
     });
-    
+
     // Mock stderr to suppress debug output during tests
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
   });
-  
+
   afterEach(() => {
     process.env = originalEnv;
     vi.restoreAllMocks();
   });
-  
+
+  const namesFrom = (text: string) =>
+    JSON.parse(text).environments.map((env: { name: string }) => env.name);
+
   it('should return empty environments when no DB configs are set', async () => {
     const result = await runEnvironmentsTool();
     expect(result).toHaveProperty('content');
     expect(result.content).toHaveLength(1);
     expect(result.content[0].type).toBe('text');
-    
+
     const parsedContent = JSON.parse(result.content[0].text);
     expect(parsedContent.environments).toEqual([]);
     expect(parsedContent.count).toBe(0);
   });
-  
+
   it('should detect local environment when LOCAL_DB_* vars are set', async () => {
     // Set up local environment variables
     process.env.LOCAL_DB_HOST = 'localhost';
     process.env.LOCAL_DB_USER = 'root';
     process.env.LOCAL_DB_NAME = 'test';
-    
+
     const result = await runEnvironmentsTool();
     const parsedContent = JSON.parse(result.content[0].text);
-    
-    expect(parsedContent.environments).toContain('local');
+
+    expect(namesFrom(result.content[0].text)).toContain('local');
     expect(parsedContent.count).toBe(1);
-    expect(parsedContent.debug.envVars).toHaveProperty('LOCAL_DB_HOST', 'localhost');
   });
-  
+
   it('should detect multiple environments when multiple DB configs are set', async () => {
     // Set up environment variables for multiple environments
     process.env.LOCAL_DB_HOST = 'localhost';
     process.env.LOCAL_DB_USER = 'root';
     process.env.LOCAL_DB_NAME = 'test';
-    
+
     process.env.DEVELOPMENT_DB_HOST = 'dev.example.com';
     process.env.DEVELOPMENT_DB_USER = 'dev_user';
     process.env.DEVELOPMENT_DB_NAME = 'dev_db';
-    
+
     const result = await runEnvironmentsTool();
     const parsedContent = JSON.parse(result.content[0].text);
-    
-    expect(parsedContent.environments).toContain('local');
-    expect(parsedContent.environments).toContain('development');
-    expect(parsedContent.environments).not.toContain('staging');
-    expect(parsedContent.environments).not.toContain('production');
+    const names = namesFrom(result.content[0].text);
+
+    expect(names).toContain('local');
+    expect(names).toContain('development');
+    expect(names).not.toContain('staging');
+    expect(names).not.toContain('production');
     expect(parsedContent.count).toBe(2);
   });
-  
+
+  it('should report how each environment was configured', async () => {
+    process.env.LOCAL_DB_HOST = 'localhost';
+    process.env.LOCAL_DB_USER = 'root';
+    process.env.LOCAL_DB_NAME = 'test';
+    process.env.LOCAL_DB_PASS = 'local-password';
+
+    const result = await runEnvironmentsTool();
+    const parsedContent = JSON.parse(result.content[0].text);
+
+    expect(parsedContent.environments[0]).toEqual({
+      name: 'local',
+      credentialSource: 'env',
+    });
+  });
+
+  it('should never return configuration values', async () => {
+    process.env.PRODUCTION_DB_HOST = 'prod.example.com';
+    process.env.PRODUCTION_DB_USER = 'prod_user';
+    process.env.PRODUCTION_DB_NAME = 'prod_db';
+    process.env.PRODUCTION_DB_PASS = 'super-secret-prod-password';
+
+    const result = await runEnvironmentsTool();
+    const text = result.content[0].text;
+
+    expect(text).not.toContain('super-secret-prod-password');
+    expect(text).not.toContain('prod.example.com');
+    expect(text).not.toContain('prod_user');
+    expect(text).not.toContain('PRODUCTION_DB_PASS');
+    expect(JSON.parse(text)).not.toHaveProperty('debug');
+  });
+
   it('should handle errors gracefully', async () => {
     // Mock Environment.enum to throw an error
     vi.spyOn(Environment, 'enum', 'get').mockImplementation(() => {
       throw new Error('Test error');
     });
-    
+
     await expect(runEnvironmentsTool()).rejects.toThrow('Test error');
   });
-}); 
+});

--- a/tests/tools/info.test.ts
+++ b/tests/tools/info.test.ts
@@ -21,14 +21,11 @@ const mockResponses = [
   // Variables query
   [[
     { Variable_name: 'max_connections', Value: '151' } as RowDataPacket,
-    { Variable_name: 'version', Value: '8.0.32' } as RowDataPacket
+    { Variable_name: 'version', Value: '8.0.32' } as RowDataPacket,
+    { Variable_name: 'secure_file_priv', Value: '/var/lib/mysql-files/' } as RowDataPacket,
+    { Variable_name: 'datadir', Value: '/var/lib/mysql/' } as RowDataPacket
   ], [] as FieldPacket[]],
-  
-  // Process list query
-  [[
-    { Id: 1, User: 'root', Host: 'localhost', Command: 'Query', Time: 0 } as RowDataPacket
-  ], [] as FieldPacket[]],
-  
+
   // Databases query
   [[
     { Database: 'mysql' } as RowDataPacket,
@@ -108,15 +105,32 @@ describe('info tool', () => {
     expect(parsedContent).toHaveProperty('version', '8.0.32');
     expect(parsedContent).toHaveProperty('status', 'Up 12345 seconds');
     expect(parsedContent.variables).toHaveProperty('max_connections', '151');
-    expect(parsedContent.processlist).toHaveLength(1);
+    expect(parsedContent.counters).toHaveProperty('Threads_connected', '10');
     expect(parsedContent.databases).toContain('mysql');
     expect(parsedContent.databases).toContain('test');
-    
+
     // Verify connection was released
     expect(releaseCalled).toBe(true);
-    
+
     // Verify all queries were called
-    expect(queryCount).toBe(5);
+    expect(queryCount).toBe(4);
+  });
+
+  it('should not report the process list', async () => {
+    const result = await runInfoTool({ environment: 'local' });
+    const parsedContent = JSON.parse(result.content[0].text);
+
+    // SHOW PROCESSLIST exposes other sessions' in-flight query text.
+    expect(parsedContent).not.toHaveProperty('processlist');
+  });
+
+  it('should only report allowlisted server variables', async () => {
+    const result = await runInfoTool({ environment: 'local' });
+    const parsedContent = JSON.parse(result.content[0].text);
+
+    expect(parsedContent.variables).toHaveProperty('version');
+    expect(parsedContent.variables).not.toHaveProperty('secure_file_priv');
+    expect(parsedContent.variables).not.toHaveProperty('datadir');
   });
   
   it('should throw error when environment not found', async () => {


### PR DESCRIPTION
## Description

The `environments` tool returned a `debug` object containing every `*_DB_*` environment variable and its value, `*_DB_PASS` included. Asking an assistant which databases it could see returned the host, username, and plaintext password for every configured environment, production included. This has already put real production credentials into a chat transcript.

Two related exposures are fixed in the same PR: the `info` tool returned the full output of `SHOW VARIABLES` and `SHOW PROCESSLIST`, and debug logging on stderr printed hostnames, usernames, and configuration values.

### Deployment model, and why there is no OAuth here

This is exclusively a local stdio server: `bin` entry, `StdioServerTransport`, spawned per developer by their own MCP client. The MCP Authorization spec explicitly does not apply:

> Implementations using an HTTP-based transport **SHOULD** conform to this specification. Implementations using an **STDIO** transport **SHOULD NOT** follow this specification, and instead retrieve credentials from the environment.

There is no shared or hosted deployment goal for this project, so OAuth 2.1, PKCE, Dynamic Client Registration, and RFC 8707 resource indicators would add no real boundary. Anyone who can spawn the process already has the access those would protect. Reading credentials from the environment stays.

### What the actual boundary violation was

Storing credentials in the local MCP client config is inside the developer's own trust boundary and is the prescribed pattern. A tool *response* is a different boundary. Anything returned is written into the calling model's context and into a saved transcript, so it leaves the machine it was configured on, and it is reachable by prompt injection from any untrusted content the model reads. Storing credentials in the environment is correct; handing them back out is not.

### Changes

- `environments` returns environment names and how each was configured, nothing else.
- `info` reports an allowlist of server variables plus aggregate connection counters. The full variable dump and the process list are gone. The process list carried the in-flight query text of every other session on the server.
- Every tool response passes through `guardToolResponse` before leaving the process. It scans for the value of any secret-named env var, for configuration-shaped keys, and for AWS keys, PEM blocks, and connection URIs with an embedded password. It **fails closed**: a suspect response is blocked, not scrubbed and forwarded.
- All logging goes through one redacting logger. Verbose output now requires `DEBUG=true` instead of being always on.
- `SECURITY.md` documents the vulnerability class and tells existing users to rotate every credential configured through this server.

Detection deliberately does not match hostnames or usernames by value, or object keys merely named `password`. A real query result can legitimately contain all three (`SELECT password_hash FROM users` is a query someone asked for), and blocking those would break the tool. The configuration-shaped-key rule covers the leak those would have caught.

### Not in this PR

Credential *storage* is unchanged and still plaintext env vars. `docs/product-brief-credentials.md` records the plan: resolving credentials from a reference (OS keychain, a helper command, AWS Secrets Manager) so the config file holds no secrets, then RDS IAM auth so AWS environments need no stored password. Those are additive and land separately.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue) - `fix:`
- [x] New feature (non-breaking change which adds functionality) - `feat:`
- [x] Documentation update - `docs:`

## Breaking Change?

- [ ] Yes (will cause existing functionality to change)
- [x] No

Config and the four-environment model are untouched. Tool *response* shapes do change: `environments` entries are now objects rather than strings, and `info` drops `processlist`, trims `variables`, and adds `counters`. Neither was a documented contract, and both changes are the fix.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) standard

## Additional Information

**Verification**

- 38 tests pass, 1 integration test skipped (needs a live database). `tsc --noEmit` clean.
- Tests reconstruct the original leaky response and assert the guard rejects it, so the next debug field carrying a secret fails the build. False-positive tests cover ordinary query output, a `password_hash` column, and usernames in data rows.
- Smoke tested the built binary over stdio with `PRODUCTION_DB_PASS` set and `DEBUG=true`. The `environments` response contains only names and credential source; the password, host, and username appear nowhere in the response or in stderr.

**Review points**

- The `info` allowlist is a judgment call. If something operationally useful is missing, add it to `REPORTED_VARIABLES`.
- The guard throws rather than returning a partial response. Failing closed on a false positive means a broken tool call, which is why the shape rules are kept narrow.
- `credentialSource` currently only ever reports `env` or `none`. It exists so the follow-up work has somewhere to report `keychain` and `aws-secrets`.
- Not addressed here and worth separate issues: `mcp_user` grants are still only enforced by the query-string validator, and `SELECT ... INTO OUTFILE` passes the read-only check.
