### PR TITLE
ci: publish to npm with trusted publishing instead of a token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,29 +76,42 @@ jobs:
     needs: create-release
     if: needs.create-release.outputs.releases_created == 'true'
     runs-on: ubuntu-latest
-    
+
+    # Publishes with npm trusted publishing (OIDC) rather than a long-lived
+    # token. id-token: write lets this job mint the short-lived OIDC token that
+    # npm exchanges for publish rights. The trust relationship is configured on
+    # the package at npmjs.com and is bound to this repository and this workflow
+    # file name, so renaming this file breaks publishing until npm is updated.
+    permissions:
+      contents: read
+      id-token: write
+
     steps:
       - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
-      
+
       - name: Use Node.js 22.13.0
         uses: actions/setup-node@v4
         with:
           node-version: 22.13.0
           registry-url: https://registry.npmjs.org/
           cache: 'npm'
-      
+
+      # Node 22.13.0 ships npm 10, which has no OIDC support. Trusted publishing
+      # needs npm 11.5.1 or later.
+      - name: Use an npm that supports trusted publishing
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm ci
-      
+
       - name: Build package
         run: npm run build
-        
+
+      # No .npmrc and no NPM_TOKEN. The npm CLI detects the OIDC environment and
+      # authenticates with it, and generates provenance automatically. Writing a
+      # token here would take precedence and defeat the point.
       - name: Publish to NPM
-        run: |
-          echo "//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}" > .npmrc
-          npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }} 
+        run: npm publish 

--- a/docs/ci-cd-setup.md
+++ b/docs/ci-cd-setup.md
@@ -2,28 +2,44 @@
 
 This guide explains how to set up the necessary GitHub environment for CI/CD automation.
 
-## Required Secrets
+## Publishing Authentication
 
-For the CI/CD pipeline to publish to npm, you need to set up a GitHub secret:
+Publishing uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers/)
+over OIDC. There is no npm token, and no publishing secret to store or rotate.
+Each publish authenticates with a short-lived token minted by GitHub for that one
+workflow run, which cannot be extracted or reused.
 
-### NPM_TOKEN
+`NPM_TOKEN` is no longer used and the repository secret can be deleted.
 
-1. **Generate an npm token**:
-   - Log in to your npm account at https://www.npmjs.com/
-   - Navigate to your profile settings
-   - Select "Access Tokens"
-   - Click "Generate New Token"
-   - Choose "Automation" token type
-   - Provide a description (e.g., "GitHub CI/CD Publishing")
-   - Copy the generated token (it will only be shown once)
+### What makes it work
 
-2. **Add the token to GitHub**:
-   - In your GitHub repository, go to "Settings"
-   - Navigate to "Secrets and variables" > "Actions"
-   - Click "New repository secret"
-   - Set Name as `NPM_TOKEN`
-   - Paste your npm token as the Value
-   - Click "Add secret"
+Three things have to agree. If any one of them is wrong, `npm publish` fails with
+a confusing `E404 Not Found - PUT`, because npm returns 404 rather than 401 for a
+package you are not authorized to publish.
+
+1. **The trusted publisher on npm.** On the package's Settings page at npmjs.com,
+   the Trusted Publisher entry must name this repository (`devakone/mysql-query-mcp-server`)
+   and the workflow file that publishes, which is `ci.yml`.
+
+2. **The `id-token: write` permission.** Granted on the `publish-npm` job in
+   `.github/workflows/ci.yml`. Without it GitHub will not mint an OIDC token.
+
+3. **npm 11.5.1 or later.** Node 22.13.0 ships npm 10, which has no OIDC support,
+   so the workflow installs a newer npm before publishing.
+
+### Gotchas
+
+- **Renaming the workflow file breaks publishing.** The trust relationship is
+  bound to the file name. If `ci.yml` is renamed or the publish job moves to
+  another file, update the Trusted Publisher entry on npm to match.
+- **Do not write an `.npmrc` auth token in the publish job.** A token takes
+  precedence over OIDC, which reintroduces exactly the long-lived credential this
+  setup removes.
+- **A separate `publish-npm.yml` triggered by `on: release` will not work here.**
+  release-please creates the GitHub release using `secrets.GITHUB_TOKEN`, and
+  events raised by `GITHUB_TOKEN` deliberately do not trigger further workflow
+  runs. That is why publishing stays in `ci.yml`, gated on release-please's
+  `releases_created` output.
 
 ## How Release Process Works
 


### PR DESCRIPTION
## Description

1.3.0 never reached the npm registry. The git tag and GitHub release exist, but `publish-npm` failed with `E404 Not Found - PUT`, which npm returns instead of 401 when the caller is not authorized to publish an existing package.

Three things were wrong at the same time:

1. **The trusted publisher never matched.** The package already has a Trusted Publisher configured at npmjs.com, but it names the workflow file `publish-npm.yml`. The only workflow in this repo is `ci.yml`.
2. **The workflow did not attempt OIDC.** It wrote an `.npmrc` with `secrets.NPM_TOKEN`.
3. **Token publishing is being restricted.** Package publishing access is set to "2FA or a granular access token with bypass 2fa enabled", and npm is restricting bypass-2FA tokens as of August 2026. A token that worked in May stops working now.

So rather than rotating the token, this uses the trusted publisher that is already configured. No publishing secret to store, leak, or rotate.

## Changes

- `id-token: write` on the `publish-npm` job so GitHub mints the short-lived OIDC token
- Upgrade npm before publishing. Node 22.13.0 ships npm 10, and trusted publishing needs 11.5.1 or later
- Remove the `.npmrc` write and `NODE_AUTH_TOKEN`. A token takes precedence over OIDC and would defeat the point
- `docs/ci-cd-setup.md` rewritten: what the three moving parts are, and the gotchas

Provenance is generated automatically on the OIDC path, so published versions get a verified link back to this commit.

## Action required outside this repo

**Before merging**, change the Trusted Publisher on npm so the workflow file is `ci.yml` rather than `publish-npm.yml`:
Settings -> Trusted Publisher -> Edit -> workflow filename -> `ci.yml`.

Merging without that leaves publishing broken in the same way, just for a different reason.

Afterwards the `NPM_TOKEN` repository secret can be deleted.

## Why publishing stays in ci.yml

The alternative is a separate `publish-npm.yml` triggered by `on: release`, which would match the current npm config with no UI change. That does not work here: release-please creates the GitHub release using `secrets.GITHUB_TOKEN`, and events raised by `GITHUB_TOKEN` deliberately do not trigger further workflow runs, so the publish job would silently never run. Publishing therefore stays gated on release-please's `releases_created` output.

## Type of Change

- [x] Build/CI related changes - `ci:`
- [x] Documentation update - `docs:`

## Breaking Change?

- [x] No

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) standard

## Additional Information

**Verification limits, stated plainly.** A publish path cannot be fully proven until it runs on `main`. I verified the YAML parses, the job has the permission, and no `_authToken` write or `NODE_AUTH_TOKEN` reference remains. Whether npm accepts the OIDC exchange depends on the npm-side config above, which I cannot see or change from here.

**Recovering 1.3.0.** After this merges and the npm setting is updated, 1.3.0 can be published without cutting a new version, because the tag and release already exist:

```
gh run rerun 30955529992 --failed
```

If that re-run does not pick up the new workflow, the fallback is an empty `Release-As: 1.3.0` commit to regenerate the release.

**Sources**
- [npm trusted publishing GA](https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/)
- [Trusted publishing for npm packages](https://docs.npmjs.com/trusted-publishers/)