### PR TITLE
feat(credentials): resolve passwords from a reference instead of plaintext config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,29 @@
+# Passwords
+#
+# Two ways to give this server a password, per environment:
+#
+#   <ENV>_DB_PASS         the password itself, in plaintext
+#   <ENV>_DB_PASS_SOURCE  where to read it from, so no secret is stored here
+#
+# _DB_PASS_SOURCE is preferred for anything that is not a throwaway local
+# database, and takes precedence if both are set. Supported sources:
+#
+#   keychain://mysql-query-mcp/production
+#   cmd:op read op://Infra/prod-mysql/password
+#   cmd:vault kv get -field=password kv/mysql/prod
+#   cmd:aws secretsmanager get-secret-value --secret-id prod/mysql --query SecretString --output text
+#   aws-secrets://prod/mysql#password
+#   aws-ssm:///prod/mysql/password
+#   env:SOME_OTHER_VAR
+#
+# Put a password in your OS keychain with:
+#   mysql-query-mcp credentials set production
+#
+# Check what resolves, without starting the server:
+#   mysql-query-mcp doctor
+
 # Local Database
+# A throwaway local password inline is fine.
 LOCAL_DB_HOST=localhost
 LOCAL_DB_USER=root
 LOCAL_DB_PASS=your_password
@@ -9,7 +34,7 @@ LOCAL_DB_SSL=false
 # Development Database
 DEVELOPMENT_DB_HOST=dev.example.com
 DEVELOPMENT_DB_USER=dev_user
-DEVELOPMENT_DB_PASS=dev_password
+DEVELOPMENT_DB_PASS_SOURCE=keychain://mysql-query-mcp/development
 DEVELOPMENT_DB_NAME=dev_database
 DEVELOPMENT_DB_PORT=3306
 DEVELOPMENT_DB_SSL=true
@@ -17,7 +42,7 @@ DEVELOPMENT_DB_SSL=true
 # Staging Database
 STAGING_DB_HOST=staging.example.com
 STAGING_DB_USER=staging_user
-STAGING_DB_PASS=staging_password
+STAGING_DB_PASS_SOURCE=keychain://mysql-query-mcp/staging
 STAGING_DB_NAME=staging_database
 STAGING_DB_PORT=3306
 STAGING_DB_SSL=true
@@ -25,10 +50,10 @@ STAGING_DB_SSL=true
 # Production Database
 PRODUCTION_DB_HOST=prod.example.com
 PRODUCTION_DB_USER=prod_user
-PRODUCTION_DB_PASS=prod_password
+PRODUCTION_DB_PASS_SOURCE=keychain://mysql-query-mcp/production
 PRODUCTION_DB_NAME=prod_database
 PRODUCTION_DB_PORT=3306
 PRODUCTION_DB_SSL=true
 
 # Debug Mode
-DEBUG=false 
+DEBUG=false

--- a/README.md
+++ b/README.md
@@ -218,17 +218,35 @@ npm install -g mysql-query-mcp-server @aws-sdk/client-secrets-manager
 
 ### Migrating from inline passwords
 
-Existing configs keep working, so this can be done one environment at a time.
+Already using `[ENV]_DB_PASS`? Nothing breaks, and you can migrate one
+environment at a time. Only the password line changes:
 
-1. `mysql-query-mcp credentials set production`
-2. Replace `"PRODUCTION_DB_PASS": "..."` with the `PRODUCTION_DB_PASS_SOURCE`
-   line it prints.
-3. `mysql-query-mcp doctor` to confirm it resolves.
-4. Restart your AI tool so the MCP server picks up the new config.
+```diff
+  "PRODUCTION_DB_HOST": "prod.example.com",
+  "PRODUCTION_DB_USER": "mcp_user",
+- "PRODUCTION_DB_PASS": "actual-production-password",
++ "PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production",
+  "PRODUCTION_DB_NAME": "app"
+```
 
-Rotate any password that has been sitting in a config file, since it may be in
-your shell history, an editor backup, or a previous chat transcript. See
-[SECURITY.md](SECURITY.md).
+Because `_DB_PASS_SOURCE` takes precedence over `_DB_PASS`, you can add the new
+line, prove it works, then remove the old one, with nothing broken in between:
+
+```bash
+mysql-query-mcp credentials set production   # stores it, prints the line to paste
+# add PRODUCTION_DB_PASS_SOURCE to your config, leave PRODUCTION_DB_PASS for now
+mysql-query-mcp doctor                       # confirm it says: production ... keychain  resolved
+# now delete PRODUCTION_DB_PASS, and restart your AI tool
+```
+
+Then rotate the old password. Moving it out of a file does not un-leak it, since
+that value may still be in your shell history, an editor backup, or a previous
+chat transcript.
+
+**[docs/MIGRATION.md](docs/MIGRATION.md) has the full guide**, including recipes
+for getting an existing password into 1Password, Vault, AWS Secrets Manager, and
+SSM without putting it in your shell history, plus rollback and what to do when a
+source does not resolve.
 
 ## Configuration Options
 
@@ -416,6 +434,8 @@ If you're having trouble connecting:
 - Verify your SQL syntax
 - Check that you're only using supported query types (SELECT, SHOW, DESCRIBE)
 - Ensure your query is truly read-only
+
+To move existing passwords out of your config file, see the [Migration Guide](docs/MIGRATION.md).
 
 For more comprehensive troubleshooting, see the [Troubleshooting Guide](docs/TROUBLESHOOTING.md).
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,13 @@ Create or edit your MCP configuration file (e.g., `.cursor/mcp.json` for Cursor 
 }
 ```
 
-**Comprehensive Configuration with Database Credentials:**
+**Comprehensive Configuration:**
+
+Store each password where it belongs and point at it, so this file holds no
+secrets and is safe to commit and share. Run `mysql-query-mcp credentials set
+production` first to put the password in your OS keychain. See
+[Credential Sources](#credential-sources).
+
 ```json
 {
   "mysql": {
@@ -78,25 +84,25 @@ Create or edit your MCP configuration file (e.g., `.cursor/mcp.json` for Cursor 
       "LOCAL_DB_PASS": "<YOUR_LOCAL_DB_PASSWORD>",
       "LOCAL_DB_NAME": "your_database",
       "LOCAL_DB_PORT": "3306",
-      
+
       "DEVELOPMENT_DB_HOST": "dev.example.com",
       "DEVELOPMENT_DB_USER": "<DEV_USER>",
-      "DEVELOPMENT_DB_PASS": "<DEV_PASSWORD>",
+      "DEVELOPMENT_DB_PASS_SOURCE": "keychain://mysql-query-mcp/development",
       "DEVELOPMENT_DB_NAME": "your_database",
       "DEVELOPMENT_DB_PORT": "3306",
-      
+
       "STAGING_DB_HOST": "staging.example.com",
       "STAGING_DB_USER": "<STAGING_USER>",
-      "STAGING_DB_PASS": "<STAGING_PASSWORD>",
+      "STAGING_DB_PASS_SOURCE": "keychain://mysql-query-mcp/staging",
       "STAGING_DB_NAME": "your_database",
       "STAGING_DB_PORT": "3306",
-      
+
       "PRODUCTION_DB_HOST": "prod.example.com",
       "PRODUCTION_DB_USER": "<PRODUCTION_USER>",
-      "PRODUCTION_DB_PASS": "<PRODUCTION_PASSWORD>",
+      "PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production",
       "PRODUCTION_DB_NAME": "your_database",
       "PRODUCTION_DB_PORT": "3306",
-      
+
       "DEBUG": "false",
       "MCP_MYSQL_SSL": "true",
       "MCP_MYSQL_REJECT_UNAUTHORIZED": "false",
@@ -105,6 +111,10 @@ Create or edit your MCP configuration file (e.g., `.cursor/mcp.json` for Cursor 
   }
 }
 ```
+
+Only `LOCAL_DB_PASS` is left as a plaintext password above, because a throwaway
+local database password is not worth the ceremony. Everything else reads from the
+keychain.
 
 ### Choosing the Right Configuration Approach
 
@@ -129,8 +139,96 @@ Choose the approach that best fits your workflow. Both methods will work correct
 - Global settings like DEBUG, MCP_MYSQL_SSL apply to all environments
 - At least one environment (typically "local") must be configured
 - You only need to configure the environments you plan to use
-- For security reasons, consider using environment variables or secure credential storage for production credentials
+- Use `[ENV]_DB_PASS_SOURCE` rather than `[ENV]_DB_PASS` for anything you care about, so no password is stored in this file. See [Credential Sources](#credential-sources)
+- Run `mysql-query-mcp doctor` to check your configuration without starting the server
 - DATETIME, DATE, and TIMESTAMP columns are returned as strings to preserve the exact value stored in MySQL without host timezone shifting
+
+## Credential Sources
+
+By default a password sits in plaintext in your MCP client config file, which
+means that file cannot be committed, shared, or used as an example. Set
+`[ENV]_DB_PASS_SOURCE` instead and the config holds only a reference. The
+password is fetched once at startup and kept in memory.
+
+### Quickest path: your OS keychain
+
+```bash
+mysql-query-mcp credentials set production
+```
+
+That prompts for the password (input is hidden), stores it in the macOS Keychain
+or libsecret, and prints the line to add:
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"
+```
+
+Then remove `PRODUCTION_DB_PASS` from your config and check it worked:
+
+```bash
+mysql-query-mcp doctor
+```
+
+### All supported sources
+
+| Source | Example | Notes |
+|--------|---------|-------|
+| `keychain:` | `keychain://mysql-query-mcp/production` | macOS Keychain, or libsecret on Linux. Not available on Windows, use `cmd:` there |
+| `cmd:` | `cmd:op read op://Infra/prod-mysql/password` | Runs a command, uses its stdout. Covers every secret manager with no extra dependency |
+| `aws-secrets:` | `aws-secrets://prod/mysql#password` | AWS Secrets Manager. `#password` reads that key out of a JSON secret. Requires `@aws-sdk/client-secrets-manager` |
+| `aws-ssm:` | `aws-ssm:///prod/mysql/password` | SSM Parameter Store, decrypted. Requires `@aws-sdk/client-ssm` |
+| `env:` | `env:SOME_OTHER_VAR` | Reads another environment variable. Mostly for CI |
+
+`cmd:` is the most flexible and needs nothing installed beyond the tool you
+already use:
+
+```jsonc
+// 1Password
+"PRODUCTION_DB_PASS_SOURCE": "cmd:op read op://Infra/prod-mysql/password"
+
+// HashiCorp Vault
+"PRODUCTION_DB_PASS_SOURCE": "cmd:vault kv get -field=password kv/mysql/prod"
+
+// AWS, using the CLI you already have, with no extra npm package
+"PRODUCTION_DB_PASS_SOURCE": "cmd:aws secretsmanager get-secret-value --secret-id prod/mysql --query SecretString --output text"
+
+// pass, on Linux
+"PRODUCTION_DB_PASS_SOURCE": "cmd:pass show mysql/production"
+```
+
+The AWS SDK packages are not bundled, because they add roughly 11 MB for a
+minority of users and the `cmd:` line above does the same job. Install one only
+if you prefer the native source:
+
+```bash
+npm install -g mysql-query-mcp-server @aws-sdk/client-secrets-manager
+```
+
+### Behavior notes
+
+- `[ENV]_DB_PASS_SOURCE` takes precedence over `[ENV]_DB_PASS`. If both are set
+  the server warns and uses the source.
+- A source that fails to resolve disables only its own environment. A broken
+  production reference does not stop you querying local.
+- Configuring `production` with a plaintext `PRODUCTION_DB_PASS` logs a warning
+  on startup. It still works. Other environments are not nagged.
+- Resolved passwords are registered with the same guard that protects
+  environment variables, so they cannot appear in a tool response or a log line.
+- Resolution happens once at startup. If a password changes, restart the server.
+
+### Migrating from inline passwords
+
+Existing configs keep working, so this can be done one environment at a time.
+
+1. `mysql-query-mcp credentials set production`
+2. Replace `"PRODUCTION_DB_PASS": "..."` with the `PRODUCTION_DB_PASS_SOURCE`
+   line it prints.
+3. `mysql-query-mcp doctor` to confirm it resolves.
+4. Restart your AI tool so the MCP server picks up the new config.
+
+Rotate any password that has been sitting in a config file, since it may be in
+your shell history, an editor backup, or a previous chat transcript. See
+[SECURITY.md](SECURITY.md).
 
 ## Configuration Options
 
@@ -139,7 +237,8 @@ Choose the approach that best fits your workflow. Both methods will work correct
 | DEBUG | Enable debug logging | false |
 | [ENV]_DB_HOST | Database host for environment | - |
 | [ENV]_DB_USER | Database username | - |
-| [ENV]_DB_PASS | Database password | - |
+| [ENV]_DB_PASS | Database password, in plaintext. Prefer [ENV]_DB_PASS_SOURCE | - |
+| [ENV]_DB_PASS_SOURCE | Where to read the password from. See [Credential Sources](#credential-sources) | - |
 | [ENV]_DB_NAME | Database name | - |
 | [ENV]_DB_PORT | Database port | 3306 |
 | [ENV]_DB_SSL | Enable SSL connection | false |
@@ -246,6 +345,37 @@ List all configured environments from your configuration:
 Use the environments tool to show me which database environments are available.
 ```
 
+Returns the environment name, where its password came from, and whether it is
+ready to query:
+
+```json
+{
+  "environments": [
+    { "name": "local", "credentialSource": "env", "status": "ready" },
+    { "name": "production", "credentialSource": "keychain", "status": "ready" }
+  ],
+  "count": 2
+}
+```
+
+A `status` of `credential-error` means the credential source failed. The reason
+is deliberately not included here, because it can quote output from your secret
+manager and this response goes into a chat transcript. Run
+`mysql-query-mcp doctor` or check the server log for the reason.
+
+## Command Line
+
+```bash
+mysql-query-mcp doctor                      # check config and credential sources
+mysql-query-mcp credentials set production  # store a password in the OS keychain
+mysql-query-mcp --help                      # all options and credential sources
+mysql-query-mcp --version
+```
+
+`doctor` reports every environment, which are complete, where each password
+comes from, and whether it resolves. It never prints a credential and exits
+non-zero if any source failed, so it is usable in a setup script.
+
 ## Security Considerations
 
 - ✅ Only read-only queries are allowed (SELECT, SHOW, DESCRIBE)
@@ -254,8 +384,9 @@ Use the environments tool to show me which database environments are available.
 - ✅ Query timeouts prevent runaway operations
 - ✅ Tool responses never include configuration values, and are checked for secrets before
   being returned
-- ⚠️ Credentials are still configured as plaintext environment variables in your MCP client
-  config. Keep that file out of version control
+- ✅ Passwords can be read from your OS keychain, a secret manager, or AWS instead of being
+  stored in your config file. See [Credential Sources](#credential-sources)
+- ⚠️ If you use plaintext `[ENV]_DB_PASS`, keep that config file out of version control
 
 ### If you used a version before 1.3.0
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,6 +6,25 @@ Please report security issues privately through
 [GitHub Security Advisories](https://github.com/devakone/mysql-query-mcp-server/security/advisories/new)
 rather than opening a public issue. I aim to acknowledge reports within a few days.
 
+## Credential storage
+
+Since 1.4.0 a password does not have to live in your MCP client config file. Set
+`[ENV]_DB_PASS_SOURCE` to a reference instead and it is fetched at startup from
+your OS keychain, a secret manager command, AWS Secrets Manager, or SSM
+Parameter Store. See
+[Credential Sources](README.md#credential-sources) for setup, and run
+`mysql-query-mcp doctor` to check it.
+
+Plaintext `[ENV]_DB_PASS` still works and is the documented path for a throwaway
+local database. Using it for `production` logs a warning on startup.
+
+This is defense in depth rather than a fix for a vulnerability. A local stdio
+server's config file is inside your own trust boundary, and the MCP
+specification directs stdio servers to read credentials from the environment.
+What changes is that the file itself no longer has to contain the secret, so it
+cannot leak through version control, a backup, a screen share, or a support
+bundle.
+
 ## Advisory: database credentials returned in tool responses
 
 **Affected versions:** all releases up to and including 1.2.2

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,8 +12,9 @@ Since 1.4.0 a password does not have to live in your MCP client config file. Set
 `[ENV]_DB_PASS_SOURCE` to a reference instead and it is fetched at startup from
 your OS keychain, a secret manager command, AWS Secrets Manager, or SSM
 Parameter Store. See
-[Credential Sources](README.md#credential-sources) for setup, and run
-`mysql-query-mcp doctor` to check it.
+[Credential Sources](README.md#credential-sources) for setup,
+[docs/MIGRATION.md](docs/MIGRATION.md) for moving an existing password out of a
+config file, and run `mysql-query-mcp doctor` to check it.
 
 Plaintext `[ENV]_DB_PASS` still works and is the documented path for a throwaway
 local database. Using it for `production` logs a warning on startup.

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -1,0 +1,218 @@
+# Migrating off inline passwords
+
+This guide moves an existing `[ENV]_DB_PASS` out of your MCP client config file
+and into a credential source, so the config file holds a reference instead of a
+secret.
+
+Nothing here is required. Inline `[ENV]_DB_PASS` keeps working. Migrate the
+environments you care about, starting with production.
+
+## What changes
+
+Before, the password is in the file:
+
+```json
+"PRODUCTION_DB_HOST": "prod.example.com",
+"PRODUCTION_DB_USER": "mcp_user",
+"PRODUCTION_DB_PASS": "actual-production-password",
+"PRODUCTION_DB_NAME": "app"
+```
+
+After, the file says where to find it:
+
+```json
+"PRODUCTION_DB_HOST": "prod.example.com",
+"PRODUCTION_DB_USER": "mcp_user",
+"PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production",
+"PRODUCTION_DB_NAME": "app"
+```
+
+Only the `_DB_PASS` line changes. Host, user, port, database, and SSL settings
+stay exactly as they are.
+
+## Pick a source
+
+| Where your password lives today | Use this |
+|---|---|
+| Only in the config file, and nowhere else | `keychain:` |
+| 1Password, Bitwarden, LastPass | `cmd:` with that tool's CLI |
+| HashiCorp Vault | `cmd:vault kv get` |
+| AWS Secrets Manager | `aws-secrets:`, or `cmd:aws secretsmanager` |
+| AWS SSM Parameter Store | `aws-ssm:`, or `cmd:aws ssm` |
+| An environment variable your shell already exports | `env:` |
+
+## The safe migration order
+
+Because `_DB_PASS_SOURCE` takes precedence over `_DB_PASS`, you can add the new
+line, prove it works, and only then delete the old one. Nothing is broken in
+between.
+
+1. Put the password in the store (recipes below).
+2. Add `[ENV]_DB_PASS_SOURCE` to your config, leaving `[ENV]_DB_PASS` in place.
+3. Run `mysql-query-mcp doctor`. The environment should show your source in the
+   SOURCE column and `resolved` under PASSWORD.
+4. Delete `[ENV]_DB_PASS` from your config.
+5. Restart your AI tool so it restarts the MCP server with the new config.
+6. Rotate the old password. See [Rotate afterwards](#rotate-afterwards).
+
+During step 2 and 3 both variables are set, so the server logs a warning saying
+it is using the source and telling you to remove `[ENV]_DB_PASS`. That is
+expected mid-migration and goes away at step 4.
+
+## Getting your password into a store
+
+> These recipes read the password into a shell variable first, then pass
+> `"$PW"`. Your shell history records the literal text `"$PW"`, not the password.
+> Typing the password directly on a command line puts it in your history file.
+
+### OS keychain
+
+No shell recipe needed. This prompts, hides the input, stores it, and prints the
+line to paste:
+
+```bash
+mysql-query-mcp credentials set production
+```
+
+If you did not install globally:
+
+```bash
+npx -p mysql-query-mcp-server mysql-query-mcp credentials set production
+```
+
+Resulting config:
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"
+```
+
+### 1Password
+
+```bash
+read -rs -p "Password: " PW && echo
+op item create --category=password --title='prod mysql' "password=$PW"
+unset PW
+```
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "cmd:op read op://Private/prod mysql/password"
+```
+
+### HashiCorp Vault
+
+```bash
+read -rs -p "Password: " PW && echo
+vault kv put kv/mysql/prod "password=$PW"
+unset PW
+```
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "cmd:vault kv get -field=password kv/mysql/prod"
+```
+
+### AWS Secrets Manager
+
+```bash
+read -rs -p "Password: " PW && echo
+aws secretsmanager create-secret --name prod/mysql --secret-string "$PW"
+unset PW
+```
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "aws-secrets://prod/mysql"
+```
+
+If the secret is JSON, for example one RDS manages itself, point at the key:
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "aws-secrets://prod/mysql#password"
+```
+
+Or with no extra npm package, using the AWS CLI you already have:
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "cmd:aws secretsmanager get-secret-value --secret-id prod/mysql --query SecretString --output text"
+```
+
+### AWS SSM Parameter Store
+
+```bash
+read -rs -p "Password: " PW && echo
+aws ssm put-parameter --name /prod/mysql/password --type SecureString --value "$PW" --overwrite
+unset PW
+```
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "aws-ssm:///prod/mysql/password"
+```
+
+Note the three slashes. SSM names start with `/`, and the scheme contributes two.
+
+### An existing environment variable
+
+If something already exports the password into the environment your MCP client
+launches, point at it by name rather than copying the value:
+
+```json
+"PRODUCTION_DB_PASS_SOURCE": "env:MY_EXISTING_DB_PASSWORD"
+```
+
+## Verifying
+
+```bash
+mysql-query-mcp doctor
+```
+
+```
+ENVIRONMENT  CONFIG          SOURCE    PASSWORD  DETAIL
+local        complete        env       resolved
+development  not configured  -         -
+staging      not configured  -         -
+production   complete        keychain  resolved
+```
+
+`doctor` never prints a credential and exits non-zero if any source failed, so it
+is safe to paste output into an issue.
+
+Then restart your AI tool and ask it to list environments. Each should report the
+source you configured and `"status": "ready"`.
+
+## Rotate afterwards
+
+Moving a password out of a config file does not un-leak it. That value may still
+be in your shell history, an editor swap file, a Time Machine or Dropbox backup,
+a previous git commit, or an AI chat transcript.
+
+After migrating, change the password on the database and update the store:
+
+```bash
+mysql-query-mcp credentials set production   # or your store's CLI
+mysql-query-mcp doctor
+```
+
+If you used a version before 1.3.0, rotation is not optional. Those versions
+returned credentials in the `environments` tool response, which means they were
+written into chat transcripts. See [SECURITY.md](../SECURITY.md).
+
+## Rolling back
+
+Delete `[ENV]_DB_PASS_SOURCE` and put `[ENV]_DB_PASS` back. There is no state to
+undo, since resolution happens in memory at startup and nothing is cached.
+
+## When it does not resolve
+
+`doctor` prints the reason in the DETAIL column. The most common causes:
+
+- **Not signed in.** `op signin`, `vault login`, `aws sso login`. A source is
+  only as available as the tool behind it.
+- **Your MCP client's environment is not your shell's.** `PATH` in particular is
+  usually different, so `op` may not be found. Use an absolute path, for example
+  `cmd:/opt/homebrew/bin/op read op://...`.
+- **No keychain item.** Run `mysql-query-mcp credentials set <environment>`.
+- **`keychain:` on Windows.** Not supported, because reading Credential Manager
+  needs a native module. Use `cmd:` with `Get-Secret` or your password manager's
+  CLI.
+- **Resolved to an empty value.** Treated as a failure on purpose. Check the
+  reference points at the right field, for example `#password` on a JSON secret.
+
+More in [TROUBLESHOOTING.md](TROUBLESHOOTING.md#problem-a-credential-source-is-not-resolving).

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -62,6 +62,11 @@ PRODUCTION_DB_HOST=prod.example.com  # Correct: "PRODUCTION" is recognized
 
 ## Connection Issues
 
+> Before working through this section, run `mysql-query-mcp doctor`. It reports
+> every environment, whether its configuration is complete, where its password
+> comes from, and whether that password resolves, without starting the server or
+> connecting to a database. It never prints a credential.
+
 ### Problem: Cannot connect to database
 
 **Symptoms:**
@@ -74,26 +79,61 @@ PRODUCTION_DB_HOST=prod.example.com  # Correct: "PRODUCTION" is recognized
    - Double-check your credentials in `.env` or your MCP configuration
    - Verify you can connect to the database using another client like MySQL Workbench
 
-2. **Database server is not running**
+2. **A credential source failed to resolve**
+   - `mysql-query-mcp doctor` shows `FAILED` in the PASSWORD column and the reason in DETAIL
+   - The `environments` tool reports `"status": "credential-error"` for that environment. The reason is not in the tool response on purpose, since it can quote output from your secret manager. Use `doctor` or the server log
+   - An environment whose source fails is disabled on its own. The others keep working
+   - Common causes: not signed in to your secret manager (`op signin`, `vault login`, `aws sso login`), a keychain item that does not exist, or a typo in the reference
+
+3. **Database server is not running**
    - Check if your MySQL server is running
    - For local databases: `sudo service mysql status` (Linux) or check Activity Monitor (Mac)
 
-3. **Network/firewall restrictions**
+4. **Network/firewall restrictions**
    - Check if your database allows remote connections
    - Verify firewall settings allow connections on the configured MySQL port (`[ENV]_DB_PORT`, default `3306`)
 
-4. **Missing environment variables**
+5. **Missing environment variables**
    - Ensure all required variables for your environment are set
    - Run with `DEBUG=true` to see loaded configuration
 
-5. **Incorrect custom port**
+6. **Incorrect custom port**
    - If your MySQL server is not on `3306`, set `[ENV]_DB_PORT` explicitly
    - Ensure the value is a valid integer such as `3307`
    
-6. **Incorrect environment name**
+7. **Incorrect environment name**
    - Verify you're using one of the supported environment names: local, development, staging, production
    - Environment variables must be prefixed with LOCAL_, DEVELOPMENT_, STAGING_, or PRODUCTION_
    - You cannot use custom environment names with this tool (such as DEV_ or PROD_)
+
+### Problem: A credential source is not resolving
+
+**Symptoms:**
+- `doctor` reports `FAILED` for one environment
+- Server log shows `WARN [credentials] <env> is unavailable`
+
+**Possible causes and solutions:**
+
+1. **The keychain item does not exist**
+   - Create it: `mysql-query-mcp credentials set production`
+   - macOS: confirm with `security find-generic-password -s mysql-query-mcp -a production`
+   - Linux: `secret-tool` must be installed (`libsecret-tools` on Debian and Ubuntu)
+
+2. **`keychain:` on Windows**
+   - Not supported, because reading Windows Credential Manager requires a native module
+   - Use `cmd:` instead, for example `cmd:powershell -Command "Get-Secret -Name prod-mysql -AsPlainText"`
+
+3. **The command works in your shell but not here**
+   - The command runs through `/bin/sh -c` with the environment your MCP client gave the server, which is usually not your interactive shell environment. `PATH` in particular may differ
+   - Use an absolute path, for example `cmd:/opt/homebrew/bin/op read op://Infra/db/password`
+
+4. **An AWS source reports a missing package**
+   - `aws-secrets:` and `aws-ssm:` need an SDK that is not bundled
+   - Either install it alongside the server, or use the AWS CLI through `cmd:`, which the error message spells out for you
+
+5. **The source resolved to an empty value**
+   - Treated as a failure on purpose, since an empty password would fail at connection time with a much less obvious error
+   - Check the reference points at the right field, for example `#password` on a JSON secret
 
 ### Problem: SSL connection errors
 

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -135,6 +135,8 @@ PRODUCTION_DB_HOST=prod.example.com  # Correct: "PRODUCTION" is recognized
    - Treated as a failure on purpose, since an empty password would fail at connection time with a much less obvious error
    - Check the reference points at the right field, for example `#password` on a JSON secret
 
+For step-by-step setup of each source, see the [Migration Guide](MIGRATION.md).
+
 ### Problem: SSL connection errors
 
 **Symptoms:**

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,183 @@
+import { createInterface } from "node:readline";
+import { Environment } from "./types/index.js";
+import { resolvePassword, CREDENTIAL_SCHEMES } from "./credentials/index.js";
+import { DEFAULT_SERVICE, writeToKeychain } from "./credentials/keychain.js";
+
+/**
+ * Setup and diagnostic commands.
+ *
+ * These run instead of the MCP server and write to stdout, which is safe only
+ * because the server is not running. Nothing here ever prints a credential.
+ */
+
+const ENV_PREFIX_MAP = {
+  local: 'LOCAL',
+  development: 'DEVELOPMENT',
+  staging: 'STAGING',
+  production: 'PRODUCTION'
+} as const;
+
+/** Returns true when a subcommand ran, meaning the server should not start. */
+export async function runSubcommand(argv: string[]): Promise<boolean> {
+  const [command, ...rest] = argv;
+
+  switch (command) {
+    case 'doctor':
+      await doctor();
+      return true;
+    case 'credentials':
+      await credentials(rest);
+      return true;
+    default:
+      return false;
+  }
+}
+
+/**
+ * Resolves every configured environment and reports what happened, without
+ * starting the server or connecting to any database.
+ */
+async function doctor(): Promise<void> {
+  const rows: string[][] = [['ENVIRONMENT', 'CONFIG', 'SOURCE', 'PASSWORD', 'DETAIL']];
+
+  for (const environment of Object.values(Environment.enum)) {
+    const envPrefix = ENV_PREFIX_MAP[environment];
+    const hasHost = !!process.env[`${envPrefix}_DB_HOST`];
+    const hasUser = !!process.env[`${envPrefix}_DB_USER`];
+    const hasName = !!process.env[`${envPrefix}_DB_NAME`];
+    const configured = hasHost && hasUser && hasName;
+
+    if (!configured && !process.env[`${envPrefix}_DB_PASS_SOURCE`]) {
+      rows.push([environment, 'not configured', '-', '-', '']);
+      continue;
+    }
+
+    const missing = [
+      !hasHost && `${envPrefix}_DB_HOST`,
+      !hasUser && `${envPrefix}_DB_USER`,
+      !hasName && `${envPrefix}_DB_NAME`,
+    ].filter(Boolean);
+
+    const credential = await resolvePassword({ environment, envPrefix });
+
+    rows.push([
+      environment,
+      missing.length ? `missing ${missing.join(', ')}` : 'complete',
+      credential.source,
+      credential.error ? 'FAILED' : credential.password ? 'resolved' : 'none',
+      credential.error ?? '',
+    ]);
+  }
+
+  printTable(rows);
+
+  const anyFailure = rows.slice(1).some((row) => row[3] === 'FAILED');
+  const anyPlaintextProduction =
+    process.env.PRODUCTION_DB_PASS && !process.env.PRODUCTION_DB_PASS_SOURCE;
+
+  if (anyPlaintextProduction) {
+    console.log(
+      '\nWarning: production uses a plaintext password in PRODUCTION_DB_PASS.\n' +
+        'Move it out of your config file with:\n' +
+        '  mysql-query-mcp credentials set production',
+    );
+  }
+
+  if (anyFailure) {
+    console.log('\nOne or more credential sources failed. Those environments will be unavailable.');
+    process.exitCode = 1;
+  }
+}
+
+async function credentials(args: string[]): Promise<void> {
+  const [action, target] = args;
+
+  if (action !== 'set' || !target) {
+    console.log(
+      'Usage:\n' +
+        '  mysql-query-mcp credentials set <environment>\n\n' +
+        'Stores a password in the OS credential store and prints the config line to add.\n' +
+        `Environments: ${Object.values(Environment.enum).join(', ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const parsed = Environment.safeParse(target);
+  if (!parsed.success) {
+    console.error(
+      `Unknown environment "${target}". Expected one of: ${Object.values(Environment.enum).join(', ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const environment = parsed.data;
+  const password = await promptHidden(`Password for ${environment}: `);
+
+  if (!password) {
+    console.error('No password entered, nothing stored.');
+    process.exitCode = 1;
+    return;
+  }
+
+  try {
+    await writeToKeychain(DEFAULT_SERVICE, environment, password);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.error(`Could not write to the OS credential store: ${message}`);
+    console.error(
+      `\nAlternative: keep the password in your own secret manager and use the cmd: source.\n` +
+        `Supported sources: ${CREDENTIAL_SCHEMES.map((s) => `${s}:`).join(' ')}`,
+    );
+    process.exitCode = 1;
+    return;
+  }
+
+  const envPrefix = ENV_PREFIX_MAP[environment];
+  console.log(
+    `\nStored. Add this to your MCP client config and remove ${envPrefix}_DB_PASS:\n\n` +
+      `  "${envPrefix}_DB_PASS_SOURCE": "keychain://${DEFAULT_SERVICE}/${environment}"\n\n` +
+      `Verify with: mysql-query-mcp doctor`,
+  );
+}
+
+/** Reads a line from the terminal without echoing it. */
+function promptHidden(prompt: string): Promise<string> {
+  return new Promise((resolve) => {
+    const input = process.stdin;
+    const wasRaw = input.isTTY ? input.isRaw : false;
+
+    const rl = createInterface({ input, output: process.stdout, terminal: true });
+
+    // Suppress echo by overriding the readline output writer.
+    const originalWrite = (rl as any)._writeToOutput;
+    (rl as any)._writeToOutput = function (text: string) {
+      if (text.includes(prompt)) {
+        originalWrite.call(this, text);
+      }
+    };
+
+    rl.question(prompt, (answer) => {
+      rl.close();
+      if (input.isTTY && !wasRaw) input.setRawMode?.(false);
+      process.stdout.write('\n');
+      resolve(answer.trim());
+    });
+  });
+}
+
+function printTable(rows: string[][]): void {
+  const widths = rows[0].map((_, column) =>
+    Math.max(...rows.map((row) => (row[column] ?? '').length)),
+  );
+
+  for (const row of rows) {
+    console.log(
+      row
+        .map((cell, column) => (cell ?? '').padEnd(widths[column]))
+        .join('  ')
+        .trimEnd(),
+    );
+  }
+}

--- a/src/credentials/aws.ts
+++ b/src/credentials/aws.ts
@@ -1,0 +1,138 @@
+import type { CredentialResolver } from "./types.js";
+
+/**
+ * AWS-backed credential sources.
+ *
+ * The SDK clients are loaded on demand and are not bundled, so the base install
+ * stays pure JavaScript for the majority of users who do not need them. Both use
+ * the caller's existing credential chain (environment, shared config, SSO,
+ * instance or task role), so this introduces no new secret to manage.
+ */
+
+/**
+ * The SDK packages are not declared as dependencies, optional or otherwise.
+ * They add roughly 11 MB, which is a poor trade for every user when the cmd:
+ * source already covers AWS through the AWS CLI with no dependency at all.
+ *
+ * The specifier is held in a variable so that TypeScript does not try to
+ * resolve a package that is intentionally absent from this project.
+ */
+const SECRETS_MANAGER_PACKAGE = '@aws-sdk/client-secrets-manager';
+const SSM_PACKAGE = '@aws-sdk/client-ssm';
+
+function missingDependency(packageName: string, alternative: string, cause: unknown): Error {
+  const detail = cause instanceof Error ? cause.message : String(cause);
+  return new Error(
+    `${packageName} is not installed, so this source cannot be used. Either install it ` +
+      `alongside this server (npm install -g mysql-query-mcp-server ${packageName}), or use ` +
+      `the cmd: source with the AWS CLI, which needs no extra package:\n  ${alternative}\n` +
+      `(${detail})`,
+  );
+}
+
+/**
+ * `aws-secrets://<secret-id>[#json-key]`
+ *
+ * Without a fragment the whole secret string is the password. With one, the
+ * secret is parsed as JSON and that key is read, which matches the shape RDS
+ * writes when it manages a secret ({"username":...,"password":...}).
+ */
+export const resolveFromSecretsManager: CredentialResolver = async (reference) => {
+  const [secretId, jsonKey] = splitFragment(reference);
+
+  if (!secretId) {
+    throw new Error('no secret id given, expected aws-secrets://<secret-id>[#json-key]');
+  }
+
+  let SecretsManagerClient: any;
+  let GetSecretValueCommand: any;
+  try {
+    ({ SecretsManagerClient, GetSecretValueCommand } = await import(SECRETS_MANAGER_PACKAGE));
+  } catch (error) {
+    throw missingDependency(
+      SECRETS_MANAGER_PACKAGE,
+      `cmd:aws secretsmanager get-secret-value --secret-id ${secretId} ` +
+        `--query SecretString --output text`,
+      error,
+    );
+  }
+
+  const client = new SecretsManagerClient({});
+  const response = await client.send(new GetSecretValueCommand({ SecretId: secretId }));
+  const secretString: string | undefined = response.SecretString;
+
+  if (!secretString) {
+    throw new Error(`secret "${secretId}" has no string value (binary secrets are not supported)`);
+  }
+
+  if (!jsonKey) {
+    return secretString;
+  }
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(secretString);
+  } catch {
+    throw new Error(
+      `secret "${secretId}" is not JSON, so the #${jsonKey} key cannot be read. ` +
+        `Drop the fragment to use the whole value`,
+    );
+  }
+
+  const value = parsed[jsonKey];
+  if (typeof value !== 'string' || !value) {
+    throw new Error(`secret "${secretId}" has no string value at key "${jsonKey}"`);
+  }
+
+  return value;
+};
+
+/**
+ * `aws-ssm://<parameter-name>`
+ *
+ * Parameter names start with `/`, which survives stripping the scheme's `//`,
+ * so `aws-ssm:///prod/mysql/password` and `aws-ssm://prod/mysql/password` both
+ * resolve to `/prod/mysql/password`.
+ */
+export const resolveFromParameterStore: CredentialResolver = async (reference) => {
+  const [rawName] = splitFragment(reference);
+  const name = rawName.startsWith('/') ? rawName : `/${rawName}`;
+
+  if (name === '/') {
+    throw new Error('no parameter name given, expected aws-ssm://<parameter-name>');
+  }
+
+  let SSMClient: any;
+  let GetParameterCommand: any;
+  try {
+    ({ SSMClient, GetParameterCommand } = await import(SSM_PACKAGE));
+  } catch (error) {
+    throw missingDependency(
+      SSM_PACKAGE,
+      `cmd:aws ssm get-parameter --name ${name} --with-decryption ` +
+        `--query Parameter.Value --output text`,
+      error,
+    );
+  }
+
+  const client = new SSMClient({});
+  const response = await client.send(
+    new GetParameterCommand({ Name: name, WithDecryption: true }),
+  );
+
+  const value: string | undefined = response.Parameter?.Value;
+  if (!value) {
+    throw new Error(`parameter "${name}" has no value`);
+  }
+
+  return value;
+};
+
+function splitFragment(reference: string): [string, string | undefined] {
+  const trimmed = reference.trim();
+  const hash = trimmed.indexOf('#');
+
+  return hash === -1
+    ? [trimmed, undefined]
+    : [trimmed.slice(0, hash), trimmed.slice(hash + 1) || undefined];
+}

--- a/src/credentials/command.ts
+++ b/src/credentials/command.ts
@@ -1,0 +1,50 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { CredentialResolver } from "./types.js";
+
+const run = promisify(execFile);
+
+/** Long enough for a vault CLI to prompt for biometrics, short enough to fail. */
+const TIMEOUT_MS = 30_000;
+
+/**
+ * Runs a command and uses its stdout as the password.
+ *
+ * This is the escape hatch that covers every secret manager without this
+ * project taking a dependency on any of them: 1Password (`op read`), HashiCorp
+ * Vault (`vault kv get`), `aws-vault`, `pass`, gopass, or a shell script.
+ *
+ * The command comes from the user's own MCP client config, which is the same
+ * place the command that launches this server comes from. Anyone who can set it
+ * can already run arbitrary code as this user, so running it is not a new
+ * capability.
+ */
+export const resolveFromCommand: CredentialResolver = async (reference) => {
+  const command = reference.trim();
+
+  if (!command) {
+    throw new Error('no command given, expected cmd:<command to run>');
+  }
+
+  const [file, args] = process.platform === 'win32'
+    ? ['cmd.exe', ['/d', '/s', '/c', command]]
+    : ['/bin/sh', ['-c', command]];
+
+  try {
+    const { stdout } = await run(file, args, {
+      timeout: TIMEOUT_MS,
+      maxBuffer: 1024 * 64,
+      windowsHide: true,
+    });
+
+    // Trailing newlines are near universal in CLI output and are not part of
+    // the secret. Interior whitespace is left alone.
+    return stdout.replace(/\r?\n$/, '');
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    // stderr is included because it is usually the only clue ("not signed in",
+    // "vault sealed"). Secret managers write the secret to stdout, not stderr.
+    const stderr = (error as { stderr?: string }).stderr?.trim();
+    throw new Error(stderr ? `${detail}: ${stderr}` : detail);
+  }
+};

--- a/src/credentials/index.ts
+++ b/src/credentials/index.ts
@@ -1,0 +1,140 @@
+import type { Environment } from "../types/index.js";
+import { registerSecret } from "../security/secrets.js";
+import { warn } from "../logging.js";
+import { resolveFromCommand } from "./command.js";
+import { resolveFromKeychain } from "./keychain.js";
+import { resolveFromParameterStore, resolveFromSecretsManager } from "./aws.js";
+import type { CredentialResolver, ResolveContext, ResolvedCredential } from "./types.js";
+
+export type { ResolveContext, ResolvedCredential } from "./types.js";
+
+/**
+ * Password resolution for one environment.
+ *
+ * `<ENV>_DB_PASS_SOURCE` holds a reference to where the password lives rather
+ * than the password itself, so the MCP client config file contains no secrets
+ * and can be committed and shared. `<ENV>_DB_PASS` still works and is the
+ * documented local and throwaway path.
+ */
+
+const RESOLVERS: Record<string, CredentialResolver> = {
+  env: async (reference) => {
+    const name = reference.trim();
+    if (!name) throw new Error('no variable name given, expected env:VARIABLE_NAME');
+
+    const value = process.env[name];
+    if (!value) throw new Error(`environment variable ${name} is not set or is empty`);
+
+    return value;
+  },
+  cmd: resolveFromCommand,
+  keychain: resolveFromKeychain,
+  'aws-secrets': resolveFromSecretsManager,
+  'aws-ssm': resolveFromParameterStore,
+};
+
+export const CREDENTIAL_SCHEMES = Object.keys(RESOLVERS);
+
+export interface ParsedReference {
+  scheme: string;
+  target: string;
+}
+
+/**
+ * Splits `scheme:target` and strips a leading `//` from the target, so both
+ * `keychain:production` and `keychain://mysql-query-mcp/production` work.
+ * Returns null when there is no scheme at all.
+ */
+export function parseReference(reference: string): ParsedReference | null {
+  const match = /^([a-z][a-z0-9+.-]*):(.*)$/is.exec(reference.trim());
+  if (!match) return null;
+
+  return {
+    scheme: match[1].toLowerCase(),
+    target: match[2].replace(/^\/\//, ''),
+  };
+}
+
+/**
+ * Resolves the password for one environment. Never throws: a failure is
+ * reported in the returned object so that one broken source disables only its
+ * own environment and the others keep working.
+ */
+export async function resolvePassword(context: ResolveContext): Promise<ResolvedCredential> {
+  const { environment, envPrefix } = context;
+  const reference = process.env[`${envPrefix}_DB_PASS_SOURCE`]?.trim();
+  const inline = process.env[`${envPrefix}_DB_PASS`];
+
+  if (reference) {
+    if (inline) {
+      warn(
+        'credentials',
+        `${environment}: both ${envPrefix}_DB_PASS and ${envPrefix}_DB_PASS_SOURCE are set. ` +
+          `Using ${envPrefix}_DB_PASS_SOURCE. Remove ${envPrefix}_DB_PASS from your config`,
+      );
+    }
+
+    const parsed = parseReference(reference);
+    if (!parsed) {
+      return {
+        source: 'invalid',
+        error:
+          `${envPrefix}_DB_PASS_SOURCE has no scheme. Expected one of ` +
+          `${CREDENTIAL_SCHEMES.map((scheme) => `${scheme}:`).join(' ')}`,
+      };
+    }
+
+    const resolver = RESOLVERS[parsed.scheme];
+    if (!resolver) {
+      return {
+        source: 'invalid',
+        error:
+          `unknown credential source "${parsed.scheme}:". Expected one of ` +
+          `${CREDENTIAL_SCHEMES.map((scheme) => `${scheme}:`).join(' ')}`,
+      };
+    }
+
+    try {
+      const password = await resolver(parsed.target, context);
+
+      if (!password) {
+        return { source: parsed.scheme, error: 'the source resolved to an empty value' };
+      }
+
+      // Resolved secrets are not in process.env, so the response guard and the
+      // logger cannot find them by scanning it. Register them explicitly.
+      registerSecret(password);
+
+      return { password, source: parsed.scheme };
+    } catch (error) {
+      return {
+        source: parsed.scheme,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  }
+
+  if (inline) {
+    if (isSensitiveEnvironment(environment)) {
+      warn(
+        'credentials',
+        `${environment} is configured with a plaintext password in ${envPrefix}_DB_PASS. ` +
+          `Consider ${envPrefix}_DB_PASS_SOURCE with keychain:, cmd:, aws-secrets:, or ` +
+          `aws-ssm: so the password is not stored in your MCP client config file. ` +
+          `See https://github.com/devakone/mysql-query-mcp-server#credential-sources`,
+      );
+    }
+
+    return { password: inline, source: 'env' };
+  }
+
+  return { source: 'none' };
+}
+
+/**
+ * Which environments get a nag for using a plaintext password. Only production,
+ * so that local development stays quiet.
+ */
+function isSensitiveEnvironment(environment: Environment): boolean {
+  return environment === 'production';
+}

--- a/src/credentials/keychain.ts
+++ b/src/credentials/keychain.ts
@@ -1,0 +1,160 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import type { CredentialResolver, ResolveContext } from "./types.js";
+
+const run = promisify(execFile);
+
+const TIMEOUT_MS = 30_000;
+
+/** Default keychain service name, so `keychain:production` is enough. */
+export const DEFAULT_SERVICE = 'mysql-query-mcp';
+
+export interface KeychainRef {
+  service: string;
+  account: string;
+}
+
+/**
+ * Accepts `keychain://service/account`, or `keychain:account` to use the default
+ * service. The account defaults to the environment name.
+ */
+export function parseKeychainRef(reference: string, context: ResolveContext): KeychainRef {
+  const trimmed = reference.trim().replace(/^\/+/, '');
+
+  if (!trimmed) {
+    return { service: DEFAULT_SERVICE, account: context.environment };
+  }
+
+  const separator = trimmed.indexOf('/');
+  if (separator === -1) {
+    return { service: DEFAULT_SERVICE, account: trimmed };
+  }
+
+  const service = trimmed.slice(0, separator);
+  const account = trimmed.slice(separator + 1);
+
+  return {
+    service: service || DEFAULT_SERVICE,
+    account: account || context.environment,
+  };
+}
+
+/**
+ * Reads a password from the OS credential store.
+ *
+ * Implemented by shelling out to the platform tool rather than by taking a
+ * native dependency. `keytar` is unmaintained and would force a native build on
+ * every install of what is otherwise a pure JavaScript package, which is a bad
+ * trade for one lookup at startup.
+ */
+export const resolveFromKeychain: CredentialResolver = async (reference, context) => {
+  const { service, account } = parseKeychainRef(reference, context);
+
+  if (process.platform === 'darwin') {
+    return readMacOSKeychain(service, account);
+  }
+
+  if (process.platform === 'linux') {
+    return readLibsecret(service, account);
+  }
+
+  // Windows Credential Manager has no supported command-line reader for secret
+  // values. cmdkey can create and delete entries but cannot print them, and
+  // reading requires the CredRead API, which means a native module. Rather than
+  // ship something half working, point at the escape hatch that does work.
+  throw new Error(
+    `the keychain: source is not supported on ${process.platform}. Use cmd: with a ` +
+      `secret manager instead, for example ` +
+      `cmd:powershell -Command "Get-Secret -Name ${account} -AsPlainText"`,
+  );
+};
+
+async function readMacOSKeychain(service: string, account: string): Promise<string> {
+  try {
+    const { stdout } = await run(
+      'security',
+      ['find-generic-password', '-s', service, '-a', account, '-w'],
+      { timeout: TIMEOUT_MS, maxBuffer: 1024 * 64 },
+    );
+    return stdout.replace(/\r?\n$/, '');
+  } catch (error) {
+    const stderr = (error as { stderr?: string }).stderr?.trim() ?? '';
+
+    if (stderr.includes('could not be found')) {
+      throw new Error(
+        `no keychain item for service "${service}" account "${account}". ` +
+          `Create one with: mysql-query-mcp credentials set ${account}`,
+      );
+    }
+
+    throw new Error(stderr || (error instanceof Error ? error.message : String(error)));
+  }
+}
+
+async function readLibsecret(service: string, account: string): Promise<string> {
+  try {
+    const { stdout } = await run(
+      'secret-tool',
+      ['lookup', 'service', service, 'account', account],
+      { timeout: TIMEOUT_MS, maxBuffer: 1024 * 64 },
+    );
+
+    const value = stdout.replace(/\r?\n$/, '');
+    if (!value) {
+      throw new Error(
+        `no libsecret item for service "${service}" account "${account}". ` +
+          `Create one with: mysql-query-mcp credentials set ${account}`,
+      );
+    }
+
+    return value;
+  } catch (error) {
+    const code = (error as { code?: string | number }).code;
+
+    if (code === 'ENOENT') {
+      throw new Error(
+        'secret-tool is not installed. Install libsecret-tools (Debian and Ubuntu) or ' +
+          'libsecret (Fedora and Arch), or use the cmd: source with pass or another manager',
+      );
+    }
+
+    throw new Error(error instanceof Error ? error.message : String(error));
+  }
+}
+
+/** Writes a password to the OS credential store. Used by the CLI, not at runtime. */
+export async function writeToKeychain(
+  service: string,
+  account: string,
+  password: string,
+): Promise<void> {
+  if (process.platform === 'darwin') {
+    // -U updates an existing item rather than failing. Note that `security` takes
+    // the password as an argument, so it is briefly visible in this machine's
+    // process list. There is no stdin form of add-generic-password. The window is
+    // milliseconds during an interactive one-off setup on the user's own machine.
+    await run(
+      'security',
+      ['add-generic-password', '-s', service, '-a', account, '-w', password, '-U'],
+      { timeout: TIMEOUT_MS },
+    );
+    return;
+  }
+
+  if (process.platform === 'linux') {
+    await new Promise<void>((resolve, reject) => {
+      const child = execFile(
+        'secret-tool',
+        ['store', '--label', `${service}:${account}`, 'service', service, 'account', account],
+        { timeout: TIMEOUT_MS },
+        (error) => (error ? reject(error) : resolve()),
+      );
+      // secret-tool reads the secret from stdin, which keeps it out of the
+      // process argument list where other users could see it.
+      child.stdin?.end(password);
+    });
+    return;
+  }
+
+  throw new Error(`writing to the OS credential store is not supported on ${process.platform}`);
+}

--- a/src/credentials/types.ts
+++ b/src/credentials/types.ts
@@ -1,0 +1,31 @@
+import type { Environment } from "../types/index.js";
+
+export interface ResolveContext {
+  /** The environment being configured, for example "production". */
+  environment: Environment;
+  /** The env var prefix for that environment, for example "PRODUCTION". */
+  envPrefix: string;
+}
+
+/**
+ * Turns a reference into a password. The reference is whatever followed the
+ * scheme in `<ENV>_DB_PASS_SOURCE`, with any leading `//` already stripped.
+ *
+ * A resolver either returns the secret or throws with a message safe to log.
+ * It must never log or print the value itself.
+ */
+export type CredentialResolver = (reference: string, context: ResolveContext) => Promise<string>;
+
+/** Where an environment's password came from, and whether it worked. */
+export interface ResolvedCredential {
+  /** Absent when there is no password configured, or resolution failed. */
+  password?: string;
+  /**
+   * The scheme that produced it: "env", "keychain", "cmd", "aws-secrets",
+   * "aws-ssm", or "none" when nothing is configured. Reported to callers, so it
+   * must never contain a value.
+   */
+  source: string;
+  /** Present when a configured source failed to resolve. Safe to log. */
+  error?: string;
+}

--- a/src/db/options.ts
+++ b/src/db/options.ts
@@ -11,13 +11,21 @@ function getDatabasePort(envPrefix: string): number | undefined {
   return port ? Number.parseInt(port, 10) : undefined;
 }
 
-export function buildPoolOptions(envPrefix: string): PoolOptions {
+/**
+ * Builds pool options for an environment.
+ *
+ * `password` is passed in rather than read from the environment, because it may
+ * have come from a credential source (keychain, a helper command, AWS) instead
+ * of `<ENV>_DB_PASS`. It falls back to the env var so that callers which do not
+ * resolve credentials, such as the options tests, keep working.
+ */
+export function buildPoolOptions(envPrefix: string, password?: string): PoolOptions {
   const sslEnv = process.env[`${envPrefix}_DB_SSL`] ?? process.env.MCP_MYSQL_SSL;
 
   return {
     host: process.env[`${envPrefix}_DB_HOST`],
     user: process.env[`${envPrefix}_DB_USER`],
-    password: process.env[`${envPrefix}_DB_PASS`],
+    password: password ?? process.env[`${envPrefix}_DB_PASS`],
     database: process.env[`${envPrefix}_DB_NAME`],
     port: getDatabasePort(envPrefix),
     ssl: sslEnv === "true" ? {} : undefined,

--- a/src/db/pools.ts
+++ b/src/db/pools.ts
@@ -1,9 +1,25 @@
 import { createPool, Pool } from "mysql2/promise";
 import { Environment } from "../types/index.js";
 import { buildPoolOptions } from "./options.js";
+import { resolvePassword } from "../credentials/index.js";
 import { debug, warn } from "../logging.js";
 
 export const pools = new Map<Environment, Pool>();
+
+/**
+ * How each environment's password was obtained, whether or not it worked. Read
+ * by the environments tool to report capability, so the values here are scheme
+ * names only and never contain a credential.
+ */
+export const credentialSources = new Map<Environment, string>();
+
+/**
+ * Why an environment is unavailable, when a configured credential source failed.
+ * Kept out of tool responses and surfaced through logs and `doctor`, because a
+ * resolver's error text can quote whatever the underlying tool printed.
+ */
+export const credentialErrors = new Map<Environment, string>();
+
 let poolsInitialized = false;
 
 // Map of environment to env var prefix
@@ -14,39 +30,68 @@ const ENV_PREFIX_MAP = {
   production: 'PRODUCTION'
 } as const;
 
-export function initializePools() {
+export function envPrefixFor(environment: Environment): string {
+  return ENV_PREFIX_MAP[environment];
+}
+
+/**
+ * Resolves credentials and creates a pool per configured environment.
+ *
+ * Asynchronous because a credential source may shell out to a keychain or call
+ * AWS. Every environment is resolved independently, so one broken source
+ * disables only its own environment.
+ */
+export async function initializePools(): Promise<void> {
   if (poolsInitialized) {
     debug('pools', 'pools already initialized');
     return;
   }
 
-  Object.values(Environment.enum).forEach((env) => {
-    const envPrefix = ENV_PREFIX_MAP[env];
-    const config = buildPoolOptions(envPrefix);
+  for (const environment of Object.values(Environment.enum)) {
+    const envPrefix = ENV_PREFIX_MAP[environment];
+    const credential = await resolvePassword({ environment, envPrefix });
+
+    credentialSources.set(environment, credential.source);
+    if (credential.error) {
+      credentialErrors.set(environment, credential.error);
+    }
+
+    const config = buildPoolOptions(envPrefix, credential.password);
 
     // Only presence is logged, never the values. stderr is captured by the MCP
     // client and written to its log files.
-    debug('pools', `initializing ${env}`, {
+    debug('pools', `initializing ${environment}`, {
       hasHost: !!config.host,
       hasUser: !!config.user,
       hasPassword: !!config.password,
       hasDatabase: !!config.database,
       port: config.port ?? 3306,
       ssl: !!config.ssl,
+      credentialSource: credential.source,
     });
+
+    if (credential.error) {
+      warn(
+        'credentials',
+        `${environment} is unavailable: could not resolve the password from ` +
+          `${credential.source}`,
+        { reason: credential.error },
+      );
+      continue;
+    }
 
     if (config.host && config.user && config.password && config.database) {
       try {
-        pools.set(env, createPool(config));
-        debug('pools', `pool created for ${env}`);
+        pools.set(environment, createPool(config));
+        debug('pools', `pool created for ${environment}`);
       } catch (error) {
         const message = error instanceof Error ? error.message : 'Unknown error';
-        warn('pools', `could not create pool for ${env}`, { message });
+        warn('pools', `could not create pool for ${environment}`, { message });
       }
     } else {
-      debug('pools', `skipping ${env}: incomplete configuration`);
+      debug('pools', `skipping ${environment}: incomplete configuration`);
     }
-  });
+  }
 
   poolsInitialized = true;
   debug('pools', 'initialization complete', { configured: Array.from(pools.keys()) });
@@ -62,4 +107,12 @@ export async function closePools() {
       debug('pools', `error closing pool for ${env}`, { message });
     }
   }
+}
+
+/** Test seam so suites can re-run initialization with different configuration. */
+export function resetPoolsForTesting(): void {
+  pools.clear();
+  credentialSources.clear();
+  credentialErrors.clear();
+  poolsInitialized = false;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -10,35 +10,66 @@ A Model Context Protocol server for executing read-only MySQL queries.
 
 Usage:
   mysql-query-mcp [options]
+  mysql-query-mcp doctor
+  mysql-query-mcp credentials set <environment>
 
 Options:
   --help, -h      Show this help message
   --version, -v   Show version information
 
+Commands:
+  doctor                  Check every configured environment: which are complete,
+                          where each password comes from, and whether it resolves.
+                          Never prints a credential. Exits non-zero on failure.
+  credentials set <env>   Store a password in the OS credential store and print
+                          the config line to add. <env> is one of local,
+                          development, staging, production.
+
 Environment Variables:
   DEBUG                   Set to 'true' to enable debug logging
   LOCAL_DB_HOST           Local database hostname
   LOCAL_DB_USER           Local database username
-  LOCAL_DB_PASS           Local database password
   LOCAL_DB_NAME           Local database name
   LOCAL_DB_PORT           Local database port (default: 3306)
   LOCAL_DB_SSL            Set to 'true' to enable SSL for local database
-  
+  LOCAL_DB_PASS           Local database password, in plaintext
+  LOCAL_DB_PASS_SOURCE    Where to read the password from, instead of storing it
+                          in your config file. Preferred. Takes precedence over
+                          LOCAL_DB_PASS.
+
   DEVELOPMENT_DB_*        Development environment database settings
   STAGING_DB_*            Staging environment database settings
   PRODUCTION_DB_*         Production environment database settings
 
+Credential Sources (the value of <ENV>_DB_PASS_SOURCE):
+  keychain://<service>/<account>   OS credential store. macOS Keychain, or
+                                   libsecret on Linux. Not available on Windows.
+  cmd:<command>                    Run a command, use its stdout. Works with any
+                                   secret manager, for example:
+                                     cmd:op read op://Infra/prod-mysql/password
+                                     cmd:vault kv get -field=password kv/mysql
+                                     cmd:aws secretsmanager get-secret-value \\
+                                       --secret-id prod/mysql \\
+                                       --query SecretString --output text
+  aws-secrets://<id>[#key]         AWS Secrets Manager. Needs
+                                   @aws-sdk/client-secrets-manager installed.
+  aws-ssm://<name>                 SSM Parameter Store, decrypted. Needs
+                                   @aws-sdk/client-ssm installed.
+  env:<VARIABLE>                   Read another environment variable.
+
 Examples:
-  # Run with local database only
+  # Store the production password in your keychain, then point at it
+  mysql-query-mcp credentials set production
+  # -> "PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"
+
+  # Check what resolves, without starting the server
+  mysql-query-mcp doctor
+
+  # Run with local database only, password in plaintext (local development)
   LOCAL_DB_HOST=localhost LOCAL_DB_USER=root LOCAL_DB_PASS=password LOCAL_DB_NAME=mydb mysql-query-mcp
 
   # Run with debug mode enabled
   DEBUG=true mysql-query-mcp
-
-  # Run with multiple environments
-  LOCAL_DB_HOST=localhost LOCAL_DB_USER=root LOCAL_DB_PASS=password LOCAL_DB_NAME=localdb \\
-  PRODUCTION_DB_HOST=prod.example.com PRODUCTION_DB_USER=admin PRODUCTION_DB_PASS=secure \\
-  PRODUCTION_DB_NAME=proddb mysql-query-mcp
   `);
   process.exit(0);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 import { initializePools, closePools } from "./db/pools.js";
 import { debug, warn } from "./logging.js";
 import { guardToolResponse } from "./security/guard.js";
+import { runSubcommand } from "./cli.js";
 import {
   queryToolName,
   queryToolDescription,
@@ -47,7 +48,6 @@ config({ path: envPath });
 
 debug('startup', 'environment loaded', { projectRoot, envPath });
 
-initializePools();
 
 /**
  * MCP server providing MySQL database tools:
@@ -210,6 +210,16 @@ async function cleanup() {
 
 // Clean server startup function matching the PostgreSQL example
 async function runServer() {
+  // Subcommands run instead of the server. They write to stdout, which is only
+  // safe because no MCP transport is attached yet.
+  if (await runSubcommand(process.argv.slice(2))) {
+    return;
+  }
+
+  // Credential sources may shell out to a keychain or call AWS, so pool setup is
+  // asynchronous and must finish before the transport starts accepting requests.
+  await initializePools();
+
   const transport = new StdioServerTransport();
 
   await server.connect(transport);

--- a/src/security/secrets.ts
+++ b/src/security/secrets.ts
@@ -60,8 +60,33 @@ export interface SecretFinding {
 }
 
 /**
- * Collects the literal values this process must never emit, keyed by the env
- * var they came from. Read fresh on every call so that tests and late-loaded
+ * Secrets that did not come from the environment, and so cannot be found by
+ * scanning process.env: anything a credential provider resolved at startup from
+ * a keychain, a helper command, or a cloud secrets manager.
+ *
+ * Without this, the guard and the logger would silently stop protecting
+ * passwords the moment a user moved off plaintext env vars, which is exactly
+ * the direction we want them to move.
+ */
+const registeredSecrets = new Set<string>();
+
+/**
+ * Marks a resolved credential as something that must never be emitted. Safe to
+ * call more than once with the same value.
+ */
+export function registerSecret(value: string | undefined): void {
+  if (!value || value.length < MIN_SECRET_VALUE_LENGTH) return;
+  registeredSecrets.add(value);
+}
+
+/** Test seam. Production code never needs to forget a secret. */
+export function clearRegisteredSecrets(): void {
+  registeredSecrets.clear();
+}
+
+/**
+ * Collects the literal values this process must never emit, keyed by where they
+ * came from. Read fresh on every call so that tests and late-loaded
  * configuration are picked up.
  */
 export function collectSecretValues(env: NodeJS.ProcessEnv = process.env): Map<string, string> {
@@ -71,6 +96,11 @@ export function collectSecretValues(env: NodeJS.ProcessEnv = process.env): Map<s
     if (!value || value.length < MIN_SECRET_VALUE_LENGTH) continue;
     if (!SECRET_NAME_PATTERN.test(name)) continue;
     values.set(name, value);
+  }
+
+  let index = 0;
+  for (const value of registeredSecrets) {
+    values.set(`resolved-credential-${++index}`, value);
   }
 
   return values;

--- a/src/tools/environments.ts
+++ b/src/tools/environments.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { Environment } from "../types/index.js";
+import { credentialErrors, credentialSources, pools } from "../db/pools.js";
 import { debug } from "../logging.js";
 
 export const environmentsToolName = "environments";
@@ -15,18 +16,14 @@ const ENV_PREFIX_MAP = {
 } as const;
 
 /**
- * Describes where an environment's password came from. Naming the mechanism is
- * capability information, not a secret, and it tells the user which
- * environments are configured which way.
- */
-function credentialSourceFor(envPrefix: string): string {
-  return process.env[`${envPrefix}_DB_PASS`] ? 'env' : 'none';
-}
-
-/**
  * Reports which environments are usable. This response describes capability
- * only: environment names and how each one was configured. It must never carry
- * configuration values. See src/security/guard.ts.
+ * only: environment names, how each password was obtained, and whether the
+ * environment is ready to query. It must never carry configuration values.
+ *
+ * Resolution failure reasons are deliberately omitted. A resolver's error text
+ * can quote whatever the underlying secret manager printed, and this response
+ * goes into a chat transcript. Reasons are in the server log and in
+ * `mysql-query-mcp doctor`. See src/security/guard.ts.
  */
 export async function runEnvironmentsTool(
   _params?: z.infer<typeof EnvironmentsToolSchema>,
@@ -46,7 +43,8 @@ export async function runEnvironmentsTool(
     })
     .map((env) => ({
       name: env,
-      credentialSource: credentialSourceFor(ENV_PREFIX_MAP[env]),
+      credentialSource: credentialSources.get(env) ?? 'none',
+      status: statusFor(env),
     }));
 
   debug('environments', 'available environments', environments.map((env) => env.name));
@@ -60,4 +58,9 @@ export async function runEnvironmentsTool(
       }, null, 2),
     }],
   };
+}
+
+function statusFor(environment: Environment): string {
+  if (pools.has(environment)) return 'ready';
+  return credentialErrors.has(environment) ? 'credential-error' : 'unavailable';
 }

--- a/tests/credentials/keychain.test.ts
+++ b/tests/credentials/keychain.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import { parseKeychainRef, DEFAULT_SERVICE } from '../../src/credentials/keychain.js';
+
+const context = { environment: 'production' as const, envPrefix: 'PRODUCTION' };
+
+describe('keychain reference parsing', () => {
+  it('uses the default service and the environment name when given nothing', () => {
+    expect(parseKeychainRef('', context)).toEqual({
+      service: DEFAULT_SERVICE,
+      account: 'production',
+    });
+  });
+
+  it('treats a bare value as the account under the default service', () => {
+    expect(parseKeychainRef('prod-db', context)).toEqual({
+      service: DEFAULT_SERVICE,
+      account: 'prod-db',
+    });
+  });
+
+  it('splits service and account', () => {
+    expect(parseKeychainRef('my-service/my-account', context)).toEqual({
+      service: 'my-service',
+      account: 'my-account',
+    });
+  });
+
+  it('tolerates the leading slashes left by a :// style reference', () => {
+    expect(parseKeychainRef('//my-service/my-account', context)).toEqual({
+      service: 'my-service',
+      account: 'my-account',
+    });
+  });
+
+  it('keeps slashes inside the account name', () => {
+    expect(parseKeychainRef('svc/team/prod/db', context)).toEqual({
+      service: 'svc',
+      account: 'team/prod/db',
+    });
+  });
+
+  it('falls back to the environment when the account half is empty', () => {
+    expect(parseKeychainRef('my-service/', context)).toEqual({
+      service: 'my-service',
+      account: 'production',
+    });
+  });
+});

--- a/tests/credentials/resolve.test.ts
+++ b/tests/credentials/resolve.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { parseReference, resolvePassword, CREDENTIAL_SCHEMES } from '../../src/credentials/index.js';
+import { clearRegisteredSecrets, scanForSecrets } from '../../src/security/secrets.js';
+
+describe('credential reference parsing', () => {
+  it.each([
+    ['keychain:production', 'keychain', 'production'],
+    ['keychain://mysql-query-mcp/production', 'keychain', 'mysql-query-mcp/production'],
+    ['cmd:op read op://Infra/db/password', 'cmd', 'op read op://Infra/db/password'],
+    ['aws-secrets://prod/mysql#password', 'aws-secrets', 'prod/mysql#password'],
+    ['aws-ssm:///prod/mysql/password', 'aws-ssm', '/prod/mysql/password'],
+    ['env:OTHER_VAR', 'env', 'OTHER_VAR'],
+  ])('parses %s', (input, scheme, target) => {
+    expect(parseReference(input)).toEqual({ scheme, target });
+  });
+
+  it('returns null when there is no scheme', () => {
+    expect(parseReference('just-a-password')).toBeNull();
+  });
+
+  it('exposes the supported schemes', () => {
+    expect(CREDENTIAL_SCHEMES).toEqual(
+      expect.arrayContaining(['env', 'cmd', 'keychain', 'aws-secrets', 'aws-ssm']),
+    );
+  });
+});
+
+describe('password resolution', () => {
+  const originalEnv = process.env;
+  let warnings: string[];
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    Object.keys(process.env).forEach((key) => {
+      if (key.includes('_DB_')) delete process.env[key];
+    });
+
+    warnings = [];
+    vi.spyOn(process.stderr, 'write').mockImplementation((chunk: any) => {
+      warnings.push(String(chunk));
+      return true;
+    });
+    clearRegisteredSecrets();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    clearRegisteredSecrets();
+  });
+
+  it('reports source "none" when nothing is configured', async () => {
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+    expect(result).toEqual({ source: 'none' });
+  });
+
+  it('uses the inline password when only _DB_PASS is set', async () => {
+    process.env.LOCAL_DB_PASS = 'local-password';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result).toEqual({ password: 'local-password', source: 'env' });
+  });
+
+  it('does not warn about a plaintext password for local', async () => {
+    process.env.LOCAL_DB_PASS = 'local-password';
+
+    await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(warnings.join('')).not.toContain('plaintext');
+  });
+
+  it('warns when production uses a plaintext password', async () => {
+    process.env.PRODUCTION_DB_PASS = 'prod-password';
+
+    const result = await resolvePassword({ environment: 'production', envPrefix: 'PRODUCTION' });
+
+    expect(result.password).toBe('prod-password');
+    expect(warnings.join('')).toContain('plaintext password');
+    expect(warnings.join('')).toContain('PRODUCTION_DB_PASS_SOURCE');
+  });
+
+  it('never puts the password itself in the warning', async () => {
+    process.env.PRODUCTION_DB_PASS = 'prod-password-value';
+
+    await resolvePassword({ environment: 'production', envPrefix: 'PRODUCTION' });
+
+    expect(warnings.join('')).not.toContain('prod-password-value');
+  });
+
+  it('resolves through a command source', async () => {
+    process.env.STAGING_DB_PASS_SOURCE = 'cmd:printf resolved-from-command';
+
+    const result = await resolvePassword({ environment: 'staging', envPrefix: 'STAGING' });
+
+    expect(result).toEqual({ password: 'resolved-from-command', source: 'cmd' });
+  });
+
+  it('strips only the trailing newline from command output', async () => {
+    process.env.STAGING_DB_SOURCE_UNUSED = 'x';
+    process.env.STAGING_DB_PASS_SOURCE = "cmd:printf 'pass word\\n'";
+
+    const result = await resolvePassword({ environment: 'staging', envPrefix: 'STAGING' });
+
+    expect(result.password).toBe('pass word');
+  });
+
+  it('resolves through an env indirection source', async () => {
+    process.env.SOME_OTHER_SECRET = 'indirect-value';
+    process.env.LOCAL_DB_PASS_SOURCE = 'env:SOME_OTHER_SECRET';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result).toEqual({ password: 'indirect-value', source: 'env' });
+  });
+
+  it('prefers _DB_PASS_SOURCE over _DB_PASS and warns about the overlap', async () => {
+    process.env.LOCAL_DB_PASS = 'inline-password';
+    process.env.LOCAL_DB_PASS_SOURCE = 'cmd:printf from-source';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result.password).toBe('from-source');
+    expect(warnings.join('')).toContain('both LOCAL_DB_PASS and LOCAL_DB_PASS_SOURCE are set');
+  });
+
+  it('reports an unknown scheme without throwing', async () => {
+    process.env.LOCAL_DB_PASS_SOURCE = 'vault-of-mystery:some/path';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result.password).toBeUndefined();
+    expect(result.source).toBe('invalid');
+    expect(result.error).toContain('unknown credential source');
+  });
+
+  it('reports a missing scheme without throwing', async () => {
+    process.env.LOCAL_DB_PASS_SOURCE = 'oops-just-a-value';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result.source).toBe('invalid');
+    expect(result.error).toContain('no scheme');
+  });
+
+  it('reports a failing source without throwing, so other environments survive', async () => {
+    process.env.PRODUCTION_DB_PASS_SOURCE = 'cmd:exit 3';
+
+    const result = await resolvePassword({ environment: 'production', envPrefix: 'PRODUCTION' });
+
+    expect(result.password).toBeUndefined();
+    expect(result.source).toBe('cmd');
+    expect(result.error).toBeTruthy();
+  });
+
+  it('treats an empty resolved value as a failure', async () => {
+    process.env.LOCAL_DB_PASS_SOURCE = 'cmd:printf ""';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result.password).toBeUndefined();
+    expect(result.error).toContain('empty value');
+  });
+
+  it('registers a resolved password so the response guard can still catch it', async () => {
+    process.env.LOCAL_DB_PASS_SOURCE = 'cmd:printf secret-from-keychain';
+
+    await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    // The password is not in process.env, so without registration the guard
+    // would have no way to know it is a secret.
+    const findings = scanForSecrets('{"leaked":"secret-from-keychain"}');
+    expect(findings.map((finding) => finding.rule)).toContain('env-secret-value');
+  });
+
+  it('reports the AWS alternative when the SDK is absent', async () => {
+    process.env.LOCAL_DB_PASS_SOURCE = 'aws-secrets://prod/mysql#password';
+
+    const result = await resolvePassword({ environment: 'local', envPrefix: 'LOCAL' });
+
+    expect(result.source).toBe('aws-secrets');
+    expect(result.error).toContain('@aws-sdk/client-secrets-manager');
+    expect(result.error).toContain('aws secretsmanager get-secret-value');
+  });
+});

--- a/tests/db/pool-init.test.ts
+++ b/tests/db/pool-init.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import {
+  pools,
+  credentialSources,
+  credentialErrors,
+  initializePools,
+  resetPoolsForTesting,
+} from '../../src/db/pools.js';
+import { clearRegisteredSecrets } from '../../src/security/secrets.js';
+
+/**
+ * createPool does not open a connection, so these exercise real pool creation
+ * without needing a database.
+ */
+describe('pool initialization with credential sources', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    Object.keys(process.env).forEach((key) => {
+      if (key.includes('_DB_')) delete process.env[key];
+    });
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    resetPoolsForTesting();
+    clearRegisteredSecrets();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    resetPoolsForTesting();
+    clearRegisteredSecrets();
+  });
+
+  function configure(prefix: string) {
+    process.env[`${prefix}_DB_HOST`] = 'localhost';
+    process.env[`${prefix}_DB_USER`] = 'mcp_user';
+    process.env[`${prefix}_DB_NAME`] = 'app';
+  }
+
+  it('creates a pool from a resolved credential source', async () => {
+    configure('LOCAL');
+    process.env.LOCAL_DB_PASS_SOURCE = 'cmd:printf resolved-password';
+
+    await initializePools();
+
+    expect(pools.has('local')).toBe(true);
+    expect(credentialSources.get('local')).toBe('cmd');
+    expect(credentialErrors.has('local')).toBe(false);
+  });
+
+  it('still creates a pool from an inline password', async () => {
+    configure('LOCAL');
+    process.env.LOCAL_DB_PASS = 'inline-password';
+
+    await initializePools();
+
+    expect(pools.has('local')).toBe(true);
+    expect(credentialSources.get('local')).toBe('env');
+  });
+
+  it('disables only the environment whose source failed', async () => {
+    configure('LOCAL');
+    process.env.LOCAL_DB_PASS = 'inline-password';
+
+    configure('PRODUCTION');
+    process.env.PRODUCTION_DB_PASS_SOURCE = 'cmd:exit 1';
+
+    await initializePools();
+
+    expect(pools.has('local')).toBe(true);
+    expect(pools.has('production')).toBe(false);
+    expect(credentialErrors.has('production')).toBe(true);
+    expect(credentialSources.get('production')).toBe('cmd');
+  });
+
+  it('skips an environment with incomplete configuration', async () => {
+    process.env.STAGING_DB_HOST = 'staging.example.com';
+    process.env.STAGING_DB_PASS = 'staging-password';
+
+    await initializePools();
+
+    expect(pools.has('staging')).toBe(false);
+    expect(credentialErrors.has('staging')).toBe(false);
+  });
+
+  it('is idempotent', async () => {
+    configure('LOCAL');
+    process.env.LOCAL_DB_PASS = 'inline-password';
+
+    await initializePools();
+    const first = pools.get('local');
+    await initializePools();
+
+    expect(pools.get('local')).toBe(first);
+  });
+});

--- a/tests/db/pools.test.ts
+++ b/tests/db/pools.test.ts
@@ -65,8 +65,10 @@ describe('database pool options', () => {
 
     const { initializePools } = await import('../../src/db/pools.js');
 
-    initializePools();
-    initializePools();
+    // Initialization is asynchronous now that a credential source may shell out
+    // to a keychain or call AWS, so both calls have to be awaited.
+    await initializePools();
+    await initializePools();
 
     expect(createPool).toHaveBeenCalledTimes(1);
   });

--- a/tests/tools/environments.test.ts
+++ b/tests/tools/environments.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { runEnvironmentsTool } from '../../src/tools/environments.js';
+import { initializePools, resetPoolsForTesting } from '../../src/db/pools.js';
 import { Environment } from '../../src/types/index.js';
 
 describe('environments tool', () => {
@@ -18,11 +19,13 @@ describe('environments tool', () => {
 
     // Mock stderr to suppress debug output during tests
     vi.spyOn(process.stderr, 'write').mockImplementation(() => true);
+    resetPoolsForTesting();
   });
 
   afterEach(() => {
     process.env = originalEnv;
     vi.restoreAllMocks();
+    resetPoolsForTesting();
   });
 
   const namesFrom = (text: string) =>
@@ -79,13 +82,39 @@ describe('environments tool', () => {
     process.env.LOCAL_DB_NAME = 'test';
     process.env.LOCAL_DB_PASS = 'local-password';
 
+    await initializePools();
+
     const result = await runEnvironmentsTool();
     const parsedContent = JSON.parse(result.content[0].text);
 
     expect(parsedContent.environments[0]).toEqual({
       name: 'local',
       credentialSource: 'env',
+      status: 'ready',
     });
+  });
+
+  it('should report a credential source failure as a status, without the reason', async () => {
+    process.env.PRODUCTION_DB_HOST = 'prod.example.com';
+    process.env.PRODUCTION_DB_USER = 'mcp_user';
+    process.env.PRODUCTION_DB_NAME = 'app';
+    process.env.PRODUCTION_DB_PASS_SOURCE = 'cmd:exit 1';
+
+    await initializePools();
+
+    const result = await runEnvironmentsTool();
+    const text = result.content[0].text;
+    const entry = JSON.parse(text).environments[0];
+
+    expect(entry).toEqual({
+      name: 'production',
+      credentialSource: 'cmd',
+      status: 'credential-error',
+    });
+    // A resolver's error text can quote whatever the underlying tool printed,
+    // and this response goes into a chat transcript.
+    expect(text).not.toContain('exit');
+    expect(text).not.toContain('Command failed');
   });
 
   it('should never return configuration values', async () => {


### PR DESCRIPTION
## Description

Feature 2 of [docs/product-brief-credentials.md](docs/product-brief-credentials.md).

A password had to be written into the MCP client config file, which made that file impossible to commit, share, or use as a README example. Every developer redid setup by hand and kept a file of production passwords in a project folder.

`<ENV>_DB_PASS_SOURCE` now holds a *reference* and the password is fetched once at startup, kept in memory only:

```json
"PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"
```

That config file has no secrets in it. It can be committed, and it is now the README example.

| Source | Example |
|---|---|
| `keychain:` | `keychain://mysql-query-mcp/production` |
| `cmd:` | `cmd:op read op://Infra/prod-mysql/password` |
| `aws-secrets:` | `aws-secrets://prod/mysql#password` |
| `aws-ssm:` | `aws-ssm:///prod/mysql/password` |
| `env:` | `env:SOME_OTHER_VAR` |

Two commands make setup short:

```
mysql-query-mcp credentials set production   # prompts, stores in OS keychain, prints the config line
mysql-query-mcp doctor                       # reports what resolves, printing no secrets
```

## Design decisions worth reviewing

**Resolved secrets are registered with the response guard.** This is the load-bearing detail. The guard from #14 finds secrets by scanning `process.env`. A password from a keychain is not there, so without explicit registration the guard would have silently stopped protecting passwords for exactly the users who took the safe path. `registerSecret()` closes that, and there is a test asserting a keychain-resolved value is still caught.

**No new dependencies, and no native build.** Keychain access shells out to `security` and `secret-tool`. `keytar` is unmaintained and would force a native build on every install of an otherwise pure-JS package, which is a bad trade for one lookup at startup.

**The AWS SDKs are deliberately not declared, not even as optional.** They add ~11 MB for a minority of users, and `cmd:aws secretsmanager get-secret-value ...` already does the same job with nothing installed. I tried `optionalDependencies` first, measured the cost, and backed it out. The error when an SDK is missing prints the equivalent `cmd:` line.

**Windows `keychain:` reports a clear error instead of half working.** Reading Windows Credential Manager needs the `CredRead` API, so a native module. `cmdkey` can write but not read. The error points at `cmd:` with a working PowerShell example. This is a deviation from the brief, which promised Windows Credential Manager support.

**Failure is per environment.** A broken production source disables production only, and local keeps working. An empty resolved value is treated as a failure, since an empty password fails later with a much less obvious error.

**Resolution errors stay out of tool responses.** A resolver's error text can quote whatever the secret manager printed, and tool responses land in chat transcripts. `environments` reports `"status": "credential-error"` and the reason goes to the log and `doctor`.

## Migrating an existing setup

Nothing breaks. Inline `[ENV]_DB_PASS` keeps working, so this is opt-in and can be done one environment at a time. Only the password line changes:

```diff
  "PRODUCTION_DB_HOST": "prod.example.com",
  "PRODUCTION_DB_USER": "mcp_user",
- "PRODUCTION_DB_PASS": "actual-production-password",
+ "PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production",
  "PRODUCTION_DB_NAME": "app"
```

Because `_DB_PASS_SOURCE` takes precedence over `_DB_PASS`, you can add the new line, prove it works, and only then delete the old one, with nothing broken in between:

```bash
mysql-query-mcp credentials set production   # prompts, stores it, prints the line to paste
# add PRODUCTION_DB_PASS_SOURCE, leave PRODUCTION_DB_PASS in place for now
mysql-query-mcp doctor                       # production ... keychain  resolved
# now delete PRODUCTION_DB_PASS, restart your AI tool, then rotate the old password
```

The overlap warning that fires while both are set is expected mid-migration and is explained in the guide.

If the password is already in a secret manager, there is nothing to move. Point at it:

| Where it lives today | Config line |
|---|---|
| Only in the config file | `"PRODUCTION_DB_PASS_SOURCE": "keychain://mysql-query-mcp/production"` |
| 1Password | `"PRODUCTION_DB_PASS_SOURCE": "cmd:op read op://Infra/prod-mysql/password"` |
| HashiCorp Vault | `"PRODUCTION_DB_PASS_SOURCE": "cmd:vault kv get -field=password kv/mysql/prod"` |
| AWS Secrets Manager | `"PRODUCTION_DB_PASS_SOURCE": "aws-secrets://prod/mysql#password"` |
| AWS SSM | `"PRODUCTION_DB_PASS_SOURCE": "aws-ssm:///prod/mysql/password"` |
| An env var already exported | `"PRODUCTION_DB_PASS_SOURCE": "env:MY_EXISTING_DB_PASSWORD"` |

[docs/MIGRATION.md](docs/MIGRATION.md) is the full guide: a recipe per store for getting an existing password *in* without putting it in your shell history, verification, rollback, rotation, and the common resolution failures. Linked from the README credential section, the README doc list, SECURITY.md, and TROUBLESHOOTING.md.

Migrating does not un-leak a password that has been sitting in a file, so the guide ends on rotation, and notes that for anyone on a version before 1.3.0 rotation is not optional.

## Backward compatibility

`<ENV>_DB_PASS` keeps working with no config change, documented as the local and throwaway path. When both are set, `_DB_PASS_SOURCE` wins and the server warns. Using plaintext for `production` warns on startup but still works, because breaking existing installs is worse than the thing being warned about. Other environments are not nagged.

Pool setup is asynchronous now, since a source may shell out or call AWS, and is awaited before the transport accepts requests.

## Type of Change

- [x] New feature (non-breaking change which adds functionality) - `feat:`
- [x] Documentation update - `docs:`

## Breaking Change?

- [x] No

`environments` gains a `status` field, which is additive. The four-environment model is untouched.

## Checklist

- [x] My code follows the project's coding style
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] My commit messages follow the [conventional commits](https://www.conventionalcommits.org/) standard

## Additional Information

**Verification**

- 74 tests pass (up from 38), `tsc --noEmit` clean. 34 new tests across reference parsing, every precedence path, both warnings, failure isolation, empty resolution, and secret registration.
- Live keychain round-trip on macOS through the built binary: wrote an item, read it back, confirmed the missing-item error text, deleted the item.
- `doctor` and the `environments` tool exercised against the real binary with a `cmd:` source and a plaintext production password. Confirmed both warnings fire, the table renders, and the resolved password appears nowhere in the response or stderr.
- Rebased onto #17, so this lands on the fixed publish pipeline.

**Not verified**

- `keychain:` on Linux and the two AWS sources are covered by unit tests for parsing and error paths, not against a real libsecret daemon or a real AWS account. I have no Linux box or AWS credentials in this environment.

**Docs**

README gained a Credential Sources section, a Command Line section, a migration walkthrough, and a secret-free example config. `docs/MIGRATION.md` is new. `--help`, `.env.example`, `SECURITY.md`, and `TROUBLESHOOTING.md` updated to match. The startup warning links to `README.md#credential-sources`; I verified that anchor resolves.

**Review point.** `SECURITY.md` says "Since 1.4.0". A squash merge collapses this to one `feat:` commit, so release-please should produce 1.4.0. Worth confirming the release PR says 1.4.0 before merging it, given how 1.2.3 happened.
